### PR TITLE
Publish ci-just-in-case to GHCR (container + screenshot test)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,113 @@
+name: Publish container
+
+# Builds the container, runs it, screenshots its web UI as a gate, then pushes
+# to GHCR. The marketplace manifest pins :latest, so every push to main republishes
+# :latest (plus an immutable :sha-<short> tag).
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/companionintelligence/ci-just-in-case
+  INTERNAL_PORT: "8080"
+
+jobs:
+  publish:
+    name: Build, screenshot-test, publish
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Compute tags
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          short="$(git rev-parse --short HEAD)"
+          echo "sha_tag=${IMAGE_NAME}:sha-${short}" >> "$GITHUB_OUTPUT"
+          tags="${IMAGE_NAME}:latest,${IMAGE_NAME}:sha-${short}"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            tags="${tags},${IMAGE_NAME}:${GITHUB_REF_NAME}"
+          fi
+          echo "tags=${tags}" >> "$GITHUB_OUTPUT"
+
+      - name: Build image (load for testing)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ steps.meta.outputs.sha_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start container
+        run: docker run -d --name app -p 8080:${INTERNAL_PORT} ${{ steps.meta.outputs.sha_tag }}
+
+      - name: Wait for HTTP
+        run: |
+          for i in $(seq 1 60); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/ || true)"
+            if [ "$code" != "000" ] && [ "$code" -lt 500 ]; then echo "up ($code)"; exit 0; fi
+            sleep 2
+          done
+          echo "container never responded"; docker logs app; exit 1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Container screenshot test
+        run: |
+          cd tests/container
+          npm install
+          npx playwright install --with-deps chromium
+          APP_URL=http://localhost:8080 SCREENSHOT_PATH="$GITHUB_WORKSPACE/screenshot.png" npx playwright test
+
+      - name: Upload screenshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: container-screenshot
+          path: screenshot.png
+          if-no-files-found: warn
+
+      - name: Container logs (on failure)
+        if: failure()
+        run: docker logs app || true
+
+      - name: Tear down container
+        if: always()
+        run: docker rm -f app || true
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
+
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/vendor/sqlite-vec.c")
     add_library(sqlite_vec STATIC vendor/sqlite-vec.c)
     target_include_directories(sqlite_vec PUBLIC vendor)
     target_link_libraries(sqlite_vec PUBLIC sqlite3)
+    # Statically linked (not a loadable extension), so compile against the core
+    # SQLite API directly. Without SQLITE_CORE, sqlite3ext.h routes every call
+    # through an undeclared `sqlite3_api` pointer and the build fails with
+    # "'sqlite3_api' was not declared in this scope".
+    target_compile_definitions(sqlite_vec PRIVATE SQLITE_CORE)
 else()
     message(WARNING "vendor/sqlite-vec.c not found — "
                     "sqlite-vec must be provided at build time")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+# sqlite-vec is embedded statically and its header pulls in sqlite3ext.h; without
+# SQLITE_CORE that header routes every sqlite3_* call through an undeclared
+# `sqlite3_api` pointer. Both the sqlite-vec library AND the app sources
+# (server.cpp / ingestion.cpp include sqlite-vec.h) need it, so define it globally.
+add_compile_definitions(SQLITE_CORE)
+
 find_package(Threads REQUIRED)
 
 # ── llama.cpp build options ───────────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,9 +82,11 @@ RUN mkdir -p include/nlohmann && \
     wget -O include/nlohmann/json.hpp \
     https://github.com/nlohmann/json/releases/download/v3.11.3/json.hpp
 
-# cpp-httplib (single header)
+# cpp-httplib (single header). Pull from the tagged raw tree, not the releases
+# asset — v0.18.3 has no httplib.h release asset (the download 404s); the raw
+# single-header at the same tag is the canonical source.
 RUN wget -O include/httplib.h \
-    https://github.com/yhirose/cpp-httplib/releases/download/v0.18.3/httplib.h
+    https://raw.githubusercontent.com/yhirose/cpp-httplib/v0.18.3/httplib.h
 
 # sqlite-vec amalgamation
 RUN mkdir -p vendor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,11 +88,13 @@ RUN mkdir -p include/nlohmann && \
 RUN wget -O include/httplib.h \
     https://raw.githubusercontent.com/yhirose/cpp-httplib/v0.18.3/httplib.h
 
-# sqlite-vec amalgamation
+# sqlite-vec amalgamation. The tarball holds sqlite-vec.{c,h} at the root with no
+# top-level dir, so --strip-components=1 would strip the files themselves and
+# extract nothing (CMake then can't find vendor/sqlite-vec.c). Extract as-is.
 RUN mkdir -p vendor && \
     wget -O /tmp/sqlite-vec.tar.gz \
         https://github.com/asg017/sqlite-vec/releases/download/v0.1.6/sqlite-vec-0.1.6-amalgamation.tar.gz && \
-    tar xzf /tmp/sqlite-vec.tar.gz -C vendor --strip-components=1 && \
+    tar xzf /tmp/sqlite-vec.tar.gz -C vendor && \
     rm /tmp/sqlite-vec.tar.gz
 
 # SQLite amalgamation (with FTS5 enabled)

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN git clone --depth 1 --branch ${MUPDF_TAG} \
 FROM ubuntu:24.04 AS app-builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    build-essential cmake git wget ca-certificates \
+    build-essential cmake git wget unzip ca-certificates \
     libopenblas-dev libsqlite3-dev \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 

--- a/tests/container/.gitignore
+++ b/tests/container/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+screenshot.png
+test-results/
+playwright-report/

--- a/tests/container/package.json
+++ b/tests/container/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "container-screenshot-test",
+  "private": true,
+  "description": "Self-contained Playwright harness that screenshots the running container. Isolated from the app's own deps.",
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/tests/container/playwright.config.ts
+++ b/tests/container/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Targets an already-running container (no webServer). The publish workflow
+// starts the built image, then runs this against http://localhost:8080.
+export default defineConfig({
+  testDir: ".",
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  reporter: "list",
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL: process.env.APP_URL || "http://localhost:8080",
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1280, height: 800 },
+    // Software WebGL (SwiftShader) so three.js / WebGL apps actually render in
+    // headless CI instead of producing a blank canvas. Harmless for DOM apps.
+    launchOptions: {
+      args: [
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+        "--enable-unsafe-swiftshader",
+        "--ignore-gpu-blocklist",
+        "--enable-webgl",
+      ],
+    },
+  },
+});

--- a/tests/container/screenshot.spec.ts
+++ b/tests/container/screenshot.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+// Proves the published container actually serves a non-blank web UI, and saves a
+// screenshot artifact. Kept deliberately app-agnostic so the same spec works for
+// every CI Hub app: it passes if the page renders visible text, a canvas, or a
+// mounted SPA root.
+const url = process.env.APP_URL || "http://localhost:8080";
+
+test("container serves a non-blank web UI", async ({ page }) => {
+  const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60_000 });
+  expect(resp, "navigation should return a response").toBeTruthy();
+  expect(resp!.status(), "HTTP status should be < 400").toBeLessThan(400);
+
+  // Let an SPA mount/paint; ignore networkidle timeout for apps with long polling.
+  await page.waitForLoadState("networkidle", { timeout: 20_000 }).catch(() => {});
+
+  const canvasCount = await page.locator("canvas").count();
+  // WebGL/three.js scenes need a few frames after assets load before the first
+  // meaningful paint — give them a settle window so the screenshot isn't blank.
+  if (canvasCount > 0) {
+    await page.waitForTimeout(4_000);
+  }
+
+  const bodyText = (await page.locator("body").innerText().catch(() => "")).trim();
+  const rootCount = await page.locator("#root, #app, main, [data-reactroot]").count();
+  const hasContent = bodyText.length > 0 || canvasCount > 0 || rootCount > 0;
+
+  expect(hasContent, "page should render text, a canvas, or a mounted app root").toBeTruthy();
+
+  await page.screenshot({
+    path: process.env.SCREENSHOT_PATH || "screenshot.png",
+    fullPage: true,
+  });
+});


### PR DESCRIPTION
## Publish `ci-just-in-case` to GHCR for the CI marketplace

The marketplace lists `ghcr.io/companionintelligence/ci-just-in-case:latest`, but this repo never built or pushed that image — so the store listing 404s and the app cannot install on appliance Hubs. This PR adds the missing publish pipeline.

### What is in this PR
- `.github/workflows/docker-publish.yml` — on push to `main` (and tags) builds the image, runs a **screenshot test** gate, then pushes `:latest` + `:sha-<short>` to GHCR. PRs run build + gate without publishing.
- Container build + a self-contained `tests/container/` Playwright screenshot harness.
- Image not built locally (heavy llama.cpp/MuPDF compile); this workflow run is the first real build.

### Required one-time step after merge
GitHub creates Actions-published GHCR packages **private**. After the first publish an org owner must flip visibility to Public **once** (persists thereafter):
`https://github.com/orgs/companionintelligence/packages/container/ci-just-in-case/settings` -> Danger Zone -> Change visibility -> Public. Until then the image exists but anonymous appliance pulls get 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)