### PR TITLE
Publish linux/arm64 alongside amd64 (multi-arch)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -107,7 +110,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds a QEMU setup step and `linux/arm64` to the publish `platforms`, so the image is built and pushed for ARM appliances as well as x86_64. The amd64 image still runs the screenshot/smoke gate; arm64 is cross-built via QEMU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)