### PR TITLE
Fix the build: llama.cpp LLAMA_CURL=ON (resolve httplib link error)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM ubuntu:24.04 AS llama-builder
 
 ARG LLAMA_CPP_TAG
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    build-essential cmake git ca-certificates \
+    build-essential cmake git ca-certificates libcurl4-openssl-dev \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
@@ -32,7 +32,7 @@ RUN git clone --depth 1 --branch ${LLAMA_CPP_TAG} \
         -DLLAMA_STATIC=ON \
         -DBUILD_SHARED_LIBS=OFF \
         -DGGML_CCACHE=OFF \
-        -DLLAMA_CURL=OFF \
+        -DLLAMA_CURL=ON \
         -DGGML_STATIC=ON \
         -DGGML_CPU_BACKEND=ON \
         . && \
@@ -122,7 +122,7 @@ RUN cmake -B build \
 FROM ubuntu:24.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    libopenblas0 libgomp1 \
+    libopenblas0 libgomp1 libcurl4 \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
The publish build failed at the final link with `undefined reference to httplib::Client::...` — from **llama.cpp's own** `common/download.cpp` (in `libcommon.a`), not JIC code. With `LLAMA_CURL=OFF`, llama.cpp b8250 falls back to cpp-httplib for model downloads, but the build provides no complete httplib implementation, so those symbols are unresolved at link.

Builds llama.cpp against libcurl instead (`LLAMA_CURL=ON`), adding `libcurl4-openssl-dev` to the builder and `libcurl4` to the runtime. Models are bundled locally, so the download path is unused at runtime — this only changes how it links.

amd64-only by design (arm64 would cross-compile llama.cpp under QEMU, which is impractical — keep ci-just-in-case on the x86_64 fleet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)