### PR TITLE
Pin llama.cpp to b6591 — fixes the httplib link blocker (#10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ set(COMMON_LIBS
     nlohmann_json
     httplib
     Threads::Threads
-    m dl stdc++ pthread
+    m dl stdc++ pthread gomp
 )
 
 # ── jic-server ───────────────────────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,14 @@
 # ══════════════════════════════════════════════════════════════════════
 
 # ── Pinned versions ──────────────────────────────────────────────────
-ARG LLAMA_CPP_TAG=b8250
+# llama.cpp is pinned to b6591: the newest tag BEFORE common/ grew a
+# cpp-httplib model downloader (b6593 = PR #16185, made unconditional when
+# libcurl support was removed in PR #18828). JIC links libcommon.a with
+# --whole-archive and bundles GGUF models locally, so any in-tree HTTP
+# downloader becomes an undefined-reference at the final static link
+# (httplib::Client / curl_easy_*). At b6591 the downloader is curl-only and
+# compiles out entirely with -DLLAMA_CURL=OFF. See issue #10.
+ARG LLAMA_CPP_TAG=b6591
 ARG MUPDF_TAG=1.27.2
 
 # ═══════════════════════ Stage 1: llama.cpp ══════════════════════════
@@ -32,7 +39,7 @@ RUN git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${LLA
         -DLLAMA_STATIC=ON \
         -DBUILD_SHARED_LIBS=OFF \
         -DGGML_CCACHE=OFF \
-        -DLLAMA_CURL=ON \
+        -DLLAMA_CURL=OFF \
         -DGGML_STATIC=ON \
         -DGGML_CPU_BACKEND=ON \
         . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-RUN git clone --depth 1 --branch ${LLAMA_CPP_TAG} \
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${LLAMA_CPP_TAG} \
         https://github.com/ggml-org/llama.cpp.git && \
     cd llama.cpp && \
     cmake -B build \
@@ -53,7 +53,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-RUN git clone --depth 1 --branch ${MUPDF_TAG} \
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${MUPDF_TAG} \
         --recurse-submodules --shallow-submodules \
         https://github.com/ArtifexSoftware/mupdf.git && \
     cd mupdf && \

--- a/public/chat.js
+++ b/public/chat.js
@@ -3,6 +3,15 @@ let isProcessing = false;
 let conversationId = null;
 let useContext = true; // Toggle for using document context
 
+// Escape text destined for innerHTML interpolation
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 // Simple markdown → HTML renderer (no external deps)
 function renderMarkdown(text) {
   let html = text
@@ -71,29 +80,48 @@ function initializeChat() {
   setInterval(checkSystemStatus, 5000);
 }
 
+let statusErrorLogged = false;
+
+function ensureStatusDiv() {
+  let statusDiv = document.getElementById('system-status');
+  if (!statusDiv) {
+    statusDiv = document.createElement('div');
+    statusDiv.id = 'system-status';
+    statusDiv.setAttribute('role', 'status');
+    statusDiv.style.cssText = 'position: fixed; bottom: 10px; right: 10px; background: #333; color: white; padding: 10px; border-radius: 5px; font-size: 12px; display: flex; align-items: center; gap: 10px; z-index: 1000;';
+    document.body.appendChild(statusDiv);
+  }
+  return statusDiv;
+}
+
 function checkSystemStatus() {
   fetch('/status')
-    .then(response => response.json())
+    .then(response => {
+      if (!response.ok) throw new Error('HTTP ' + response.status);
+      return response.json();
+    })
     .then(data => {
-      const statusDiv = document.getElementById('system-status');
-      if (!statusDiv) {
-        const div = document.createElement('div');
-        div.id = 'system-status';
-        div.style.cssText = 'position: fixed; bottom: 10px; right: 10px; background: #333; color: white; padding: 10px; border-radius: 5px; font-size: 12px; display: flex; align-items: center; gap: 10px; z-index: 1000;';
-        document.body.appendChild(div);
-      }
-      
+      const statusDiv = ensureStatusDiv();
       let statusHTML = `<span>📚 ${data.documents_indexed} documents indexed</span>`;
-      
-      if (data.documents_indexed === 0) {
+
+      if (data.llm_loaded === false) {
+        statusHTML += `<span style="color: #ff9800;">⚠️ LLM model missing — answers unavailable</span>`;
+      } else if (data.documents_indexed === 0) {
         statusHTML += `<span style="color: #ff9800;">⚠️ Loading knowledge base...</span>`;
       } else {
         statusHTML += `<span style="color: #4CAF50;">✓ Ready</span>`;
       }
-      
-      document.getElementById('system-status').innerHTML = statusHTML;
+
+      statusDiv.innerHTML = statusHTML;
+      statusErrorLogged = false;
     })
-    .catch(err => console.error('Failed to check status:', err));
+    .catch(err => {
+      ensureStatusDiv().innerHTML = `<span style="color: #ff9800;">⚠️ Server unreachable</span>`;
+      if (!statusErrorLogged) {
+        console.warn('Failed to check status:', err.message);
+        statusErrorLogged = true;
+      }
+    });
 }
 
 function addBotMessage(text) {
@@ -123,12 +151,12 @@ function addSourcesMessage(sources) {
   
   let html = '<strong>📚 Sources Used:</strong>';
   sources.forEach(source => {
-    const fileUrl = '/sources/' + source.filename;
+    const fileUrl = '/sources/' + encodeURI(source.filename);
     const score = source.score ? ` (${Math.round(source.score * 100)}% relevant)` : '';
     html += `
       <div class="source-item">
-        <a href="${fileUrl}" target="_blank" title="Click to view PDF">📄 ${source.filename}</a>${score}
-        <p style="margin: 0.25rem 0 0 0; color: var(--text-secondary); font-size: 0.85em;">${source.text}</p>
+        <a href="${escapeHtml(fileUrl)}" target="_blank" rel="noopener" title="Click to view PDF">📄 ${escapeHtml(source.filename)}</a>${score}
+        <p style="margin: 0.25rem 0 0 0; color: var(--text-secondary); font-size: 0.85em;">${escapeHtml(source.text)}</p>
       </div>
     `;
   });

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Just In Case — offline emergency knowledge assistant. Search bundled survival, first-aid, and preparedness references with a local LLM. No internet required.">
   <title>Just In Case - Emergency Knowledge Assistant</title>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%A7%AD%3C/text%3E%3C/svg%3E">
   <link rel="stylesheet" href="style.css">
   <style>
     .chat-container {
@@ -210,10 +212,10 @@
 
     <div class="chat-container">
       <div class="chat-window">
-        <div class="chat-messages" id="chat-messages">
+        <div class="chat-messages" id="chat-messages" role="log" aria-live="polite" aria-label="Conversation">
           <!-- Welcome message will be added by JavaScript -->
         </div>
-        <div class="typing-indicator" id="typing-indicator">
+        <div class="typing-indicator" id="typing-indicator" aria-hidden="true">
           <span></span>
           <span></span>
           <span></span>
@@ -225,7 +227,8 @@
               class="chat-input" 
               id="user-input" 
               placeholder="Ask any emergency or survival question..."
-              onkeypress="if(event.key==='Enter' && !event.shiftKey) sendMessage()"
+              aria-label="Ask any emergency or survival question"
+              onkeydown="if(event.key==='Enter' && !event.shiftKey) sendMessage()"
             >
             <button class="send-button" id="send-button" onclick="sendMessage()">Send</button>
           </div>

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -63,6 +63,17 @@ static std::mutex g_conv_mutex;
 // ═════════════════════════════════════════════════════════════════════
 
 static void handle_query(const httplib::Request& req, httplib::Response& res) {
+    // Degraded mode: the server runs without GGUF models so the UI and
+    // /status stay reachable, but /query needs the LLM.
+    if (!g_llm) {
+        res.status = 503;
+        res.set_content(json({
+            {"error", "LLM model not loaded. Place the GGUF models in "
+                      "gguf_models/ and restart the container."}
+        }).dump(), "application/json");
+        return;
+    }
+
     try {
         auto rj = json::parse(req.body);
         std::string query = rj["query"];
@@ -98,7 +109,7 @@ static void handle_query(const httplib::Request& req, httplib::Response& res) {
         std::string context;
         json matches = json::array();
 
-        if (use_context && g_chunk_count.load() > 0) {
+        if (use_context && g_embeddings && g_chunk_count.load() > 0) {
             auto q_emb = g_embeddings->get_embedding(query);
 
             auto results = g_index->hybrid_search(
@@ -176,8 +187,10 @@ static void handle_query(const httplib::Request& req, httplib::Response& res) {
 
 static void handle_status(const httplib::Request&, httplib::Response& res) {
     json status;
-    status["documents_indexed"] = g_chunk_count.load();
-    status["files_processed"]   = g_file_count.load();
+    status["documents_indexed"]  = g_chunk_count.load();
+    status["files_processed"]    = g_file_count.load();
+    status["llm_loaded"]         = (g_llm != nullptr);
+    status["embeddings_loaded"]  = (g_embeddings != nullptr);
     res.set_content(status.dump(), "application/json");
 }
 
@@ -213,11 +226,25 @@ int main() {
     // ── Models ───────────────────────────────────────────────────────
     std::cout << "Loading models..." << std::endl;
 
+    // Missing GGUF models must not kill the server: the CI publish gate (and
+    // a fresh install before models are provisioned) runs the container with
+    // an empty gguf_models/. Serve the UI and /status regardless; /query
+    // answers 503 until the models are in place.
     g_embeddings = new EmbeddingGenerator();
-    if (!g_embeddings->init()) { std::cerr << "Embeddings init failed" << std::endl; return 1; }
+    if (!g_embeddings->init()) {
+        std::cerr << "Embeddings init failed — continuing in degraded mode "
+                     "(semantic search disabled)" << std::endl;
+        delete g_embeddings;
+        g_embeddings = nullptr;
+    }
 
     g_llm = new LLMGenerator();
-    if (!g_llm->init()) { std::cerr << "LLM init failed" << std::endl; return 1; }
+    if (!g_llm->init()) {
+        std::cerr << "LLM init failed — continuing in degraded mode "
+                     "(/query returns 503)" << std::endl;
+        delete g_llm;
+        g_llm = nullptr;
+    }
 
     // ── SQLite index ─────────────────────────────────────────────────
     fs::create_directories("data");


### PR DESCRIPTION
Fixes the `Publish container` blocker tracked in #10.

## What

1. **Pin `LLAMA_CPP_TAG` to `b6591` + build with `-DLLAMA_CURL=OFF`** (Dockerfile only).
   - b8250's `common/download.cpp` calls cpp-httplib unconditionally — libcurl support was removed upstream in ggml-org/llama.cpp#18828 (2026-01-14), so `LLAMA_CURL=ON` is a no-op there. JIC links `libcommon.a` with `--whole-archive`, which drags the downloader's `httplib::Client` references into the fully-static final link → undefined references.
   - The httplib downloader entered `common/` at **b6593** (ggml-org/llama.cpp#16185, 2025-09-26). **b6591** is the newest tag before it (b6592 was never published). At b6591 the downloader is curl-only and guarded by `LLAMA_USE_CURL`, so `-DLLAMA_CURL=OFF` compiles it out entirely. `OFF` is required: with `ON`, `libcommon.a` would carry `curl_easy_*` refs that JIC's link line doesn't resolve — the same failure class with a different library.
   - API compatibility verified before building: all **37** `llama_*` symbols used by `src/` (the post-Jan-2025 API: `llama_model_load_from_file`, `llama_init_from_model`, `llama_model_get_vocab`, `llama_vocab_is_eog`, …) exist in b6591's `include/llama.h`.

2. **Server degrades gracefully without GGUF models** (`src/server.cpp`).
   The publish workflow's screenshot gate runs the container with an empty `gguf_models/`, but `main()` exited 1 on the first failed model load — so the gate could never go green even with the link fixed. Now the server always starts; `/query` returns a 503 JSON error until models are present, and `/status` reports `llm_loaded` / `embeddings_loaded`.

3. **Static UI fixes** (`public/`): inline SVG favicon + meta description (no more favicon 404), a11y (`aria-label` on the input, `role=log aria-live=polite` on the message list, `aria-hidden` typing indicator, `keydown` for deprecated `keypress`), status pill survives backend-down without console-error spam and surfaces the degraded mode, and source filenames/snippets are HTML-escaped before `innerHTML` interpolation (`encodeURI`'d link, `rel=noopener`).

   Also carries the previously-unpushed `fix(build): link libgomp + fetch llama.cpp submodules` from the local main tree.

## Evidence (native arm64 build — validates the link fix; production stays amd64)

- `docker build` completes end-to-end; first attempt, no retries needed.
- Container without models: stays **Up (healthy)**; `GET /` → **200**, `GET /status` → `{"documents_indexed":0,"embeddings_loaded":false,"files_processed":0,"llm_loaded":false}`, `POST /query` → **503** `{"error":"LLM model not loaded. Place the GGUF models in gguf_models/ and restart the container."}`, bundled `GET /sources/100_Survival/FEMA-Emergency-Checklist.pdf` → **200**.
- `tests/container` Playwright screenshot gate (the exact CI gate): **1 passed**.
- Headless-Chromium console probe against the running container and against a backend-less static serve: **no uncaught page errors** in either.

Built/tested on arm64 (~9 min native). The amd64 CI run on this PR is the remaining proof for production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)