### PR TITLE
fix(build): link libgomp + fetch llama.cpp submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ set(COMMON_LIBS
     nlohmann_json
     httplib
     Threads::Threads
-    m dl stdc++ pthread
+    m dl stdc++ pthread gomp
 )
 
 # ── jic-server ───────────────────────────────────────────────────────

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-RUN git clone --depth 1 --branch ${LLAMA_CPP_TAG} \
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${LLAMA_CPP_TAG} \
         https://github.com/ggml-org/llama.cpp.git && \
     cd llama.cpp && \
     cmake -B build \
@@ -53,7 +53,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-RUN git clone --depth 1 --branch ${MUPDF_TAG} \
+RUN git clone --depth 1 --recurse-submodules --shallow-submodules --branch ${MUPDF_TAG} \
         --recurse-submodules --shallow-submodules \
         https://github.com/ArtifexSoftware/mupdf.git && \
     cd mupdf && \


### PR DESCRIPTION
Two link failures remained after LLAMA_CURL=ON (which doesn't help — b8250 uses cpp-httplib for downloads regardless):
- ggml-cpu.c needs OpenMP (GOMP_*/omp_*) but libgomp wasn't linked -> add gomp.
- llama.cpp common/download.cpp references cpp-httplib symbols that resolve to nothing; fetch llama.cpp's vendored submodules (--recurse-submodules) so its bundled cpp-httplib implementation is present at build.