### PR TITLE
chore: release prep — design-system changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed — Design system
+
+The `public/` web UI was aligned to the Companion Intelligence canonical design
+system. All changes are front-end only (`index.html`, `app.js`, `style.css`); the
+C++ `jic-server` and its API contract (`GET /status`, `GET /api/library`,
+`POST /query`) are unchanged.
+
+- **Canonical teal primary.** Adopted the CI canonical teal as the accent/primary
+  color — `#0f717a` in the light theme and `#abd4d8` in the dark theme (dark is the
+  default for low-light field use). The theme toggle persists to `localStorage`.
+- **Typography.** Self-hosted, offline brand fonts matching the
+  [ci.computer](https://ci.computer) site — **Abel** for display/sans and
+  **Source Code Pro** for mono — bundled as WOFF2 under `public/assets/fonts/`
+  (no CDN, OFL-licensed).
+- **Enriched design tokens (v0.2.0).** Expanded the CSS custom-property token set
+  to mirror the CI canon (`@companionintelligence/tokens` / CI-Hub `globals.css`),
+  inlined directly into `style.css`: a full teal ramp (`--teal-50`…`--teal-950`),
+  aqua/mint accent hues, semantic status colors (`--success`, `--warning`,
+  `--info` with foregrounds), brand/hero/aurora gradients, a radius scale
+  (`--radius-sm`…`--radius-2xl`), and an elevation/shadow scale — all defined per
+  theme (light + dark).
+- **Design-canon lint gate.** Added `scripts/lint-canon.mjs` (zero-dependency,
+  Node built-ins only) and the `style-canon-lint.yml` GitHub Actions workflow,
+  which fail the build if any resolvable `--primary` value drifts off the CI teal
+  (in any color notation — hex, rgb, hsl, oklch/oklab) and warn on hardcoded hex
+  in component source.
+- **Refreshed UI screenshots.** Regenerated the light and dark UI captures in
+  `docs/ui/` (welcome, grounded-answer/sources, degraded state, mobile drawer) as
+  real headless renders of `public/index.html`, and referenced them from the
+  README.
+- Completed the dark-theme gradient token set by defining `--gradient-brand` and
+  `--gradient-hero` in the default (`:root`) theme, matching the light theme so the
+  enriched gradient tokens are available in both.

--- a/public/style.css
+++ b/public/style.css
@@ -76,6 +76,8 @@
   --warning-foreground: #422006;
   --info: #38bdf8;
   --info-foreground: #082f49;
+  --gradient-brand: linear-gradient(135deg, #0f717a, #00a9a7);
+  --gradient-hero: linear-gradient(135deg, #041620, #0e4a52);
   --gradient-aurora: radial-gradient(120% 90% at 50% -10%, rgba(64, 155, 155, 0.28), transparent 60%);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
Release-prep for the merged design-system theme refactor (PRs #14–#16, all on `main`).

## What's in this PR

**CHANGELOG.md** (new, Keep-a-Changelog style) — an `## [Unreleased]` → `### Changed — Design system` entry that factually documents what landed for the `public/` web UI:

- Canonical CI teal `--primary` — light `#0f717a` / dark `#abd4d8` (dark is default), theme toggle persisted to `localStorage`.
- Self-hosted offline brand fonts matching ci.computer — **Abel** (display/sans) + **Source Code Pro** (mono), bundled WOFF2, no CDN. (This repo uses Abel/Source Code Pro, not Montserrat.)
- Enriched design tokens **v0.2.0** — full teal ramp, aqua/mint accents, semantic status (`--success`/`--warning`/`--info`), brand/hero/aurora gradients, radius scale, elevation scale — inlined into `style.css`, mirroring the CI canon (`@companionintelligence/tokens` / CI-Hub `globals.css`). Note: tokens are inlined CSS custom properties, not an npm dependency.
- Design-canon lint gate — `scripts/lint-canon.mjs` + `style-canon-lint.yml` (fails on non-teal `--primary` in any notation; warns on hardcoded hex).
- Refreshed light/dark UI screenshots in `docs/ui/`, referenced from the README.

**Safe polish** — defined `--gradient-brand` and `--gradient-hero` in the default (`:root`) dark theme so the enriched gradient tokens exist in both themes (previously only in `[data-theme="light"]`). Purely additive: no component consumes these tokens yet, so nothing renders differently. `node scripts/lint-canon.mjs .` passes; braces balanced.

## Release readiness

- **CI on `main`: green** — latest push (PR #16 merge) shows CI, Publish container, Style canon lint, and CodeQL all `success`.
- **canon lint: OK** on this branch.
- **Version:** `JIC_VERSION "0.3.0"` (`src/config.h`). A minor bump (→ `0.4.0`) is reasonable to mark the design-system release, but is **not** applied here — recommendation only.
- No code changes to the C++ server or its API; front-end token/doc only.

See agent report for full release-readiness detail.