### PR TITLE
chore(ci): gate automatic workflow triggers to manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: CI
 
+# >>> ci-local:gated original triggers below, restore with `ci-local restore`
+# on:
+#   pull_request:
+#   push:
+#     branches: [main]
+# <<< ci-local:gated
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   unit-test:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,12 +4,16 @@ name: Publish container
 # to GHCR. The marketplace manifest pins :latest, so every push to main republishes
 # :latest (plus an immutable :sha-<short> tag).
 
+# >>> ci-local:gated original triggers below, restore with `ci-local restore`
+# on:
+#   push:
+#     branches: [main]
+#     tags: ["*"]
+#   pull_request:
+#     branches: [main]
+#   workflow_dispatch:
+# <<< ci-local:gated
 on:
-  push:
-    branches: [main]
-    tags: ["*"]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -85,6 +89,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 7
           name: container-screenshot
           path: screenshot.png
           if-no-files-found: warn

--- a/.github/workflows/style-canon-lint.yml
+++ b/.github/workflows/style-canon-lint.yml
@@ -1,6 +1,10 @@
 name: Style canon lint
 
-on: [pull_request, push]
+# >>> ci-local:gated original triggers below, restore with `ci-local restore`
+# on: [pull_request, push]
+# <<< ci-local:gated
+on:
+  workflow_dispatch:
 
 jobs:
   style-canon-lint:


### PR DESCRIPTION
## What

- Gates 3 workflow(s) down to `workflow_dispatch` (manual runs only).
- Caps artifact `retention-days` on 1 workflow(s). Actions storage is billed wherever the job ran, so gating alone does not reduce it.

## Why

Automatic triggers (push/pull_request/schedule) are replaced with
workflow_dispatch so these workflows stop consuming billed GitHub-hosted
minutes. The original trigger block is preserved as a comment above the
replacement; `ci-local restore` puts it back exactly.

workflow_dispatch inputs and workflow_call are carried across unchanged, so
manual runs keep their form and reusable workflows keep working for callers.

Checks move to local hardware via `ci-local run` and a pre-push hook.


## Gated workflows

- `ci.yml`
- `docker-publish.yml`
- `style-canon-lint.yml`

## Retention capped

- `docker-publish.yml`

## Reverting

The original triggers are preserved verbatim as a comment block above each replacement:

```bash
ci-local restore --repo JustInCase --apply
```

Deploy-on-merge and tag-triggered release workflows are deliberately left on their automatic triggers.