### PR TITLE
chore(ci): gate automatic workflow triggers to manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ name: CI
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/style-canon-lint.yml
+++ b/.github/workflows/style-canon-lint.yml
@@ -6,6 +6,10 @@ name: Style canon lint
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   style-canon-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

- Adds a `concurrency` block to 2 workflow(s) so superseded runs are cancelled instead of running to completion. Deploy and release paths get `cancel-in-progress: false` - they queue rather than being interrupted mid-flight.

## Why

Automatic triggers (push/pull_request/schedule) are replaced with
workflow_dispatch so these workflows stop consuming billed GitHub-hosted
minutes. The original trigger block is preserved as a comment above the
replacement; `ci-local restore` puts it back exactly.

workflow_dispatch inputs and workflow_call are carried across unchanged, so
manual runs keep their form and reusable workflows keep working for callers.

Checks move to local hardware via `ci-local run` and a pre-push hook.


## Concurrency added

- `ci.yml`
- `style-canon-lint.yml`

## Reverting

The original triggers are preserved verbatim as a comment block above each replacement:

```bash
ci-local restore --repo JustInCase --apply
```

Deploy-on-merge and tag-triggered release workflows are deliberately left on their automatic triggers.