### PR TITLE
fix(helper-scripts): make fetch-source-data.sh bash 3.2 compatible

### DIFF
--- a/helper-scripts/fetch-source-data.sh
+++ b/helper-scripts/fetch-source-data.sh
@@ -61,6 +61,10 @@ fi
 #   url \037 category \037 filename \037 sha256 \037 title
 # Only the simple flat schema used by sources.yaml is supported.
 US=$'\037'
+
+# Lowercase a string.  bash 3.2 (macOS) has no ${var,,} expansion.
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
 parse_manifest() {
     awk '
         function val(line) {
@@ -89,7 +93,12 @@ parse_manifest() {
 # ── Validate ─────────────────────────────────────────────────────────
 validate_manifest() {
     local errors=0 count=0
-    declare -A seen
+    # Seen targets are tracked in a newline-delimited string, not an
+    # associative array: macOS ships bash 3.2, which has no `declare -A`.
+    # Quoting the key inside the pattern keeps the comparison literal, so
+    # filenames containing glob characters still match only themselves.
+    local nl=$'\n'
+    local seen="$nl"
     while IFS="$US" read -r url cat fn sha title; do
         count=$((count + 1))
         local where="entry #$count (${fn:-$url})"
@@ -115,10 +124,10 @@ validate_manifest() {
             echo "  ✗ $where: sha256 must be 64 hex chars"; errors=$((errors+1))
         fi
         local key="$cat/$fn"
-        if [[ -n "${seen[$key]:-}" ]]; then
+        if [[ "$seen" == *"$nl$key$nl"* ]]; then
             echo "  ✗ $where: duplicate target $key"; errors=$((errors+1))
         fi
-        seen[$key]=1
+        seen="$seen$key$nl"
     done < <(parse_manifest)
 
     echo ""
@@ -202,7 +211,7 @@ while IFS="$US" read -r url cat fn sha title; do
     fi
     if [[ -n "$sha" ]]; then
         actual=$(sha256sum "$part" | awk '{print $1}')
-        if [[ "${actual,,}" != "${sha,,}" ]]; then
+        if [[ "$(lower "$actual")" != "$(lower "$sha")" ]]; then
             echo "    ✗ sha256 mismatch (expected $sha, got $actual)"
             rm -f "$part"; failed=$((failed + 1)); failed_list+="    $cat/$fn — sha256 mismatch"$'\n'
             continue


### PR DESCRIPTION
## Problem

macOS ships **bash 3.2** as `/bin/bash`, and `fetch-source-data.sh` uses two bash 4+ constructs. CI runs on `ubuntu-latest` (bash 5), so this has been invisible to CI and only bites local macOS runs.

`./helper-scripts/test-config.sh` always failed its "sources.yaml validates" check on macOS:

```
./helper-scripts/fetch-source-data.sh: line 92: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

Pre-existing on `origin/main` (verified 2026-08-03), unrelated to any in-flight work.

## What's fixed

**1. `declare -A seen` in `validate_manifest()`** — the reported failure. Duplicate targets are now accumulated in a newline-delimited string.

The subtle part: the key is quoted *inside* the match pattern, so the comparison stays literal.

```bash
if [[ "$seen" == *"$nl$key$nl"* ]]; then
```

An unquoted `case`/glob rewrite would treat a filename like `Bravo-*.pdf` as a wildcard and falsely flag `Bravo-XY.pdf` as its duplicate. Quoting preserves the associative-array semantics exactly.

**2. `${actual,,}` / `${sha,,}` on the fetch path** (line 205) — same defect class, same file, found while fixing the above. Fails with `bad substitution` under bash 3.2. This one is **latent**: no `sources.yaml` entry currently sets `sha256`, so it doesn't fire today — but `sha256` is a documented manifest field, and the script dies (`set -e`) the moment someone adds one. Replaced with a small `lower()` helper.

Flagging it explicitly since it's slightly beyond the reported bug — happy to split it out if you'd rather keep this PR to the one line.

Validation semantics and **all error message strings are unchanged**.

## Verification

| Check | Result |
|---|---|
| `test-config.sh` under `/bin/bash` 3.2 (macOS) | **38 passed, 0 failed** (was 37/1) |
| `test-config.sh` under `docker run bash:5` | **36 passed, 0 failed** (docker/node checks skip in-container) |
| `shellcheck -s bash` | clean |

Because the real `sources.yaml` has **zero** duplicates, a green run doesn't actually exercise the changed branch. I ran a fixture that does — plain duplicate pair, same filename under a different category (must *not* flag), a three-way duplicate, and glob/bracket metacharacters in filenames:

```
  ✗ entry #2 (Alpha.pdf): duplicate target 100_Survival/Alpha.pdf
  ✗ entry #8 (Bravo-*.pdf): duplicate target 300_Food/Bravo-*.pdf
  ✗ entry #10 (Delta.txt): duplicate target 400_Power/Delta.txt
  ✗ entry #11 (Delta.txt): duplicate target 400_Power/Delta.txt

Manifest: 11 entries, 4 error(s)
```

Output is **byte-identical** between bash 3.2 (new code) and bash 5 (old code, captured before the edit) — `diff` clean in both directions. Note `Bravo-XY.pdf` and `Charlie-q.txt` are correctly *not* flagged, which is the glob trap.

The sha256 path was exercised end-to-end via a `file://` manifest entry: an uppercase hash matches case-insensitively, and a wrong hash is still rejected with the unchanged message and the `.part` file removed. The same input under the old code dies with `line 205: ${actual,,}: bad substitution`.

## Notes

- `sha256sum` *is* present on macOS 27 (`/sbin/sha256sum`), so no `shasum -a 256` fallback is needed. Checked while looking for further portability gaps; these two were the only bash 4+ constructs anywhere in `helper-scripts/`.
- No CI behavior change — bash 5 output is identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)