### PR TITLE
fix(video): drop the duplicate first-launch shot, and make the shot gate real

### DIFF
--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -87,33 +87,50 @@ jobs:
         working-directory: video
         run: npm run capture
 
-      # A missing PNG is NOT a build failure anywhere else in this pipeline:
-      # video-kit swaps in a branded "capture pending" slate (src/scenes.mjs
-      # shotSrc), `ci-video build` only prints a note and exits 0, `ci-video
-      # check` never looks at assets/shots, and the upload below is
-      # if-no-files-found: warn. So a run where capture silently produced
-      # nothing still goes green with an all-slate video attached. Fail here
-      # instead, naming the files, so that can never happen again.
+      # A shot with no PNG renders as a branded "capture pending" slate
+      # (video-kit src/scenes.mjs shotSrc), and `ci-video build` only prints a
+      # note about it. Two gates now stand between that slate and a shipped
+      # video, and this is the FIRST of them:
+      #
+      #   · `ci-video capture` exits 1 if any single shot failed
+      #     (bin/ci-video.mjs cmdCapture) — that is the step above.
+      #   · `ci-video check` exits 1 if any shot file is missing or empty,
+      #     unless --allow-slates is passed — that is "Build and check" below.
+      #     Never add --allow-slates here; it exists for local drafting.
+      #
+      # So this step is deliberately a duplicate of the second gate, pulled
+      # forward: it fires before `build` so a bad capture is reported next to
+      # the capture that produced it, and it emits a per-file `::error file=`
+      # annotation, which `ci-video check` does not.
+      #
+      # It calls video-kit's own `missingShots()` rather than re-deriving the
+      # filenames. An earlier hand-rolled version checked only os.path.exists,
+      # so a 0-byte PNG passed this gate and still rendered as a slate — both
+      # video-kit code paths that choose slate-vs-real require size > 0
+      # (build.mjs hasShot, capture.mjs missingShots). Use the helper.
       - name: Every shot must be captured
         working-directory: video
         run: |
-          python3 - <<'PY'
-          import json, os, sys
+          node --input-type=module -e '
+            import fs from "node:fs";
+            import { missingShots } from "@companionintelligence/video-kit/capture";
 
-          board = json.load(open("storyboard.json"))
-          ids = sorted({shot["id"] for s in board["scenes"] for shot in s.get("shots", [])})
-          # capture writes <id>.png (16:9) and <id>.mobile.png (9:16) per shot.
-          want = [f"assets/shots/{i}{v}.png" for i in ids for v in ("", ".mobile")]
-          missing = [p for p in want if not os.path.exists(p)]
+            const sb = JSON.parse(fs.readFileSync("storyboard.json", "utf8"));
+            const missing = missingShots(sb, process.cwd());
+            // Shot ids are unique across the storyboard; capture writes
+            // <id>.png (16:9) and <id>.mobile.png (9:16) for each.
+            const ids = new Set(sb.scenes.flatMap((s) => s.shots ?? []).map((s) => s.id));
+            const total = ids.size * 2;
 
-          for p in missing:
-              print(f"::error file=video/{p}::not captured — renders as a 'capture pending' slate")
-          if missing:
-              print(f"::error::{len(missing)} of {len(want)} shot PNGs missing "
-                    f"({len(ids)} shots x 2 viewports); refusing to ship a video with slates in it")
-              sys.exit(1)
-          print(f"all {len(want)} shot PNGs present ({len(ids)} shots x 2 viewports)")
-          PY
+            for (const f of missing) {
+              console.log(`::error file=video/assets/shots/${f}::missing or empty — renders as a "capture pending" slate`);
+            }
+            if (missing.length) {
+              console.log(`::error::${missing.length} of ${total} shot PNGs missing or empty; refusing to ship a video with slates in it`);
+              process.exit(1);
+            }
+            console.log(`all ${total} shot PNGs present and non-empty`);
+          '
 
       - name: Stop app
         if: always()

--- a/video/capture.config.mjs
+++ b/video/capture.config.mjs
@@ -2,7 +2,7 @@
  * Capture stage for Just In Case.
  *
  * ── The stage ────────────────────────────────────────────────────────────────
- * JIC's UI is entirely static files. `src/server.cpp:543` does
+ * JIC's UI is entirely static files. `src/server.cpp:588` does
  * `svr.set_mount_point("/", "public")` and registers exactly three JSON
  * endpoints — `GET /status`, `GET /api/library`, `POST /query`. There is no
  * framework, no bundler, no router and no auth, so the whole front end can be
@@ -87,6 +87,21 @@
  *                     drawer over an UNDIMMED chat — a state the app never
  *                     actually produces. Above 920px the eval is inert, because
  *                     `.sidebar.open` only exists inside the media query.
+ *
+ *                     COROLLARY: a shot whose ONLY difference from another shot
+ *                     is that eval is a DUPLICATE at 1280px. `empty-library`
+ *                     was exactly that — it differed from `welcome-empty` only
+ *                     by the drawer, so the two desktop PNGs came out
+ *                     byte-identical (sha256 af669a4b…) and the 16:9
+ *                     `first-launch` scene cross-dissolved one image into
+ *                     itself, as a double-exposure ghost: scenes.mjs gives f0
+ *                     `push-in` (scale 1.045) and f1 `drift-down` (y -6%), so
+ *                     the two identical layers drift apart mid-dissolve. It has
+ *                     been removed. The storyboard has no per-format shot
+ *                     selection (schema `shot` has no viewport/format key, and
+ *                     scenes.mjs shotPath keys purely off fmt.name), so a frame
+ *                     that only pays off in portrait cannot be bought without
+ *                     charging the landscape cut for it.
  *   · library scroll  The capture `{ scroll: n }` action calls window.scrollTo,
  *                     which cannot move #library-list — that pane is its own
  *                     scroll container (`.library { flex: 1; overflow-y: auto }`,
@@ -96,8 +111,19 @@
  *   · composer text   `question-typed` uses `{ fill: [...] }` and then resets
  *                     the input's caret and scrollLeft to 0. Without that reset
  *                     the 360px frame shows the question scrolled to its END
- *                     ("…v do I purify water in the field?"). FREEZE_CSS blanks
- *                     the caret, so no cursor blink drifts between runs.
+ *                     ("…l creek water to make it safe?"). FREEZE_CSS blanks the
+ *                     caret, so no cursor blink drifts between runs.
+ *                     The question it types must NOT be one of the six
+ *                     SUGGESTED_PROMPTS (app.js:29-36) — those render as chips
+ *                     directly above the composer in the same frame, and a
+ *                     shot captioned "type your own" that echoes a chip
+ *                     verbatim demonstrates the opposite of what it claims.
+ *                     `answer` and `sources-open` type and submit the SAME
+ *                     string rather than clicking a chip, so the conversation
+ *                     the video shows is the one it just watched being typed.
+ *                     The stubbed POST /query returns query.water.json for any
+ *                     question, so the answer stays on-topic for any phrasing
+ *                     of the water beat.
  *   · fonts           Abel and Source Code Pro are vendored under
  *                     public/assets/fonts — no CDN, nothing to fail offline.
  *   · chat scroll     scrollChat() pins the log to the bottom; stable for fixed

--- a/video/storyboard.json
+++ b/video/storyboard.json
@@ -33,7 +33,7 @@
       "id": "first-launch",
       "kind": "screen",
       "chapter": "first-run",
-      "seconds": 7,
+      "seconds": 6,
       "caption": "First launch. Nothing indexed yet.",
       "narration": "On first launch the library is empty, and the panel says so plainly.",
       "shots": [
@@ -51,27 +51,6 @@
               { "waitFor": "#status-pill.warn" },
               { "waitFor": ".library-empty" },
               { "waitFor": ".chips .chip" }
-            ],
-            "mask": ["#st-uptime"]
-          }
-        },
-        {
-          "id": "empty-library",
-          "url": "localhost:8080",
-          "alt": "The field library panel on first launch, saying no documents are indexed yet and naming the sources volume to drop PDFs into",
-          "motion": "drift-down",
-          "capture": {
-            "path": "/?stage=empty",
-            "waitFor": ".welcome h1",
-            "waitUntil": "networkidle",
-            "settle": 500,
-            "before": [
-              { "waitFor": "#status-pill.warn" },
-              { "waitFor": ".library-empty" },
-              {
-                "eval": "(() => { const t = document.getElementById('sidebar-toggle'); if (getComputedStyle(t).display !== 'none') { t.click(); } else { document.getElementById('sidebar').classList.add('open'); } })()"
-              },
-              { "wait": 150 }
             ],
             "mask": ["#st-uptime"]
           }
@@ -151,7 +130,7 @@
         {
           "id": "question-typed",
           "url": "localhost:8080",
-          "alt": "A question about purifying water typed into the composer, with the suggested-question chips still above it",
+          "alt": "A question of the viewer's own — how long to boil creek water — typed into the composer, with the six suggested-question chips still offered above it",
           "motion": "push-in",
           "capture": {
             "path": "/?stage=ready",
@@ -160,7 +139,7 @@
             "settle": 500,
             "before": [
               { "waitFor": ".chips .chip" },
-              { "fill": ["#user-input", "How do I purify water in the field?"] },
+              { "fill": ["#user-input", "How long do I boil creek water to make it safe?"] },
               {
                 "eval": "(() => { const i = document.getElementById('user-input'); i.setSelectionRange(0, 0); i.scrollLeft = 0; })()"
               }
@@ -181,7 +160,7 @@
         {
           "id": "answer",
           "url": "localhost:8080",
-          "alt": "A question about purifying water answered in the chat, with a collapsed sources accordion",
+          "alt": "The typed question — how long to boil creek water — asked and answered in the chat, with a collapsed sources accordion",
           "motion": "push-in",
           "capture": {
             "path": "/?stage=ready",
@@ -189,7 +168,9 @@
             "waitUntil": "networkidle",
             "settle": 600,
             "before": [
-              { "click": ".chips .chip:first-child" },
+              { "waitFor": ".chips .chip" },
+              { "fill": ["#user-input", "How long do I boil creek water to make it safe?"] },
+              { "click": "#send-button" },
               { "waitFor": ".msg.bot .msg-bubble" },
               { "waitFor": "details.sources > summary" }
             ],
@@ -217,7 +198,9 @@
             "waitUntil": "networkidle",
             "settle": 600,
             "before": [
-              { "click": ".chips .chip:first-child" },
+              { "waitFor": ".chips .chip" },
+              { "fill": ["#user-input", "How long do I boil creek water to make it safe?"] },
+              { "click": "#send-button" },
               { "waitFor": ".msg.bot .msg-bubble" },
               { "click": "details.sources > summary" },
               { "waitFor": ".source-item .source-score" },


### PR DESCRIPTION
Follow-up to #28. An adversarial verifier read the app source and reported five
defects against `main`. I reproduced each one before touching it — including a
real Playwright capture run against video-kit **0.1.2** with a static stage over
`public/`. Four confirmed, one rejected.

## Confirmed and fixed

### 1. `empty-library` was a byte-identical desktop duplicate of `welcome-empty`

At the 1280px capture viewport `#sidebar-toggle` is `display:none`
(`public/style.css:397`), so the shot's viewport-conditional eval takes the
`#sidebar.classList.add('open')` branch — which is **inert** above the 920px
breakpoint, because `.sidebar.open` only exists inside the media query
(`public/style.css:744-764`). Both `before` lists resolved to the same DOM.

Reproduced exactly:

```
af669a4b59864d1952dfb2f461e5266a847739ebb1be9b7673771b44b6bba74c  welcome-empty.png
af669a4b59864d1952dfb2f461e5266a847739ebb1be9b7673771b44b6bba74c  empty-library.png
```

This is worse than a no-op. `scenes.mjs` assigns f0 `push-in` (scale → 1.045)
and f1 `drift-down` (y → −6% of frame height), so the 0.5s cross-dissolve at
t+3.5s rendered the *same screenshot* ghosting over itself at two different
scales and offsets.

The shot was added to give the 9:16 cut the empty-library drawer, and its mobile
capture genuinely is different. But **the storyboard has no per-format shot
selection**: `schema/storyboard.schema.json` `definitions.shot` has no
viewport/format key, and `scenes.mjs shotPath()` keys purely off `fmt.name`. A
frame that only pays off in portrait cannot be bought without charging the
landscape cut for it. So the shot is **removed** and `first-launch` returns to
6s — exactly its pre-#28 shape. `first-launch.mp3` measures 5.352s
(`ffprobe`), leaving 0.65s of air, which is mid-pack for this board (`recap`
has 0.36s, `no-model-no-panic` 0.50s, `library-shelf` 0.56s).

The corollary — *a shot whose only difference from another shot is that eval is
a duplicate at 1280px* — is now written into `video/capture.config.mjs` so it is
not re-added.

### 2. A 0-byte PNG passed the new "Every shot must be captured" gate

The gate used `os.path.exists(p)` only. Both video-kit paths that choose
slate-vs-real require `size > 0` (`build.mjs` `hasShot`, `capture.mjs`
`missingShots`), so a 0-byte file passed the gate and still rendered as a
"capture pending" slate.

Reproduced verbatim — truncated `question-typed.png` to 0 bytes and ran the old
script: it printed `all 16 shot PNGs present (8 shots x 2 viewports)` and exited
0. `missingShots()` on the same tree returned `["question-typed.png"]`.

The gate now **calls `missingShots()`** instead of re-deriving the filenames in
Python, so the size condition can never drift out of it again. Re-tested: clean
tree → `all 14 shot PNGs present and non-empty`, exit 0; 0-byte `answer.png` →
per-file `::error file=` annotation, exit 1.

### 3. The gate's justifying comment was factually wrong

It claimed *"A missing PNG is NOT a build failure anywhere else in this pipeline
… `ci-video check` never looks at assets/shots. So a run where capture silently
produced nothing still goes green."* Neither half holds:

* `ci-video capture` already `process.exit(1)`s when any shot fails
  (`bin/ci-video.mjs` `cmdCapture`) — true in 0.1.1 as well as 0.1.2.
* As of video-kit **0.1.2**, `ci-video check` fails on missing *or empty* shots
  unless `--allow-slates` is passed.

The comment now describes what the step actually is: the **earlier of two
gates**, kept because it fires next to the capture that produced the bad file
and emits per-file annotations that `ci-video check` does not — plus an explicit
warning never to add `--allow-slates` to CI.

### 4. Stale citation in the header this PR rewrote for accuracy

`svr.set_mount_point("/", "public")` is at **`src/server.cpp:588`**, not `:543`
(543 is a comment about the model-loader thread). Fixed. Every other citation in
that header verifies.

### 5. `question-typed` demonstrated "type your own" using a button the UI offers

The composer was filled with `"How do I purify water in the field?"`, which is
character-for-character `SUGGESTED_PROMPTS[0]` (`public/app.js:30`) and renders
as the first chip **directly above the composer in the same frame** — visible in
the capture. The next scene then reached its state by clicking that same chip.

Now it types `"How long do I boil creek water to make it safe?"`, which is in
none of the six prompts (`public/app.js:29-36`), and `ask-a-question` /
`check-the-sources` reach their state by filling the composer with that same
string and clicking `#send-button` rather than clicking chip 1 — so the
conversation the video shows is the one it just watched being typed. The stubbed
`POST /query` returns `query.water.json` for any question
(`video/capture.config.mjs`), so the answer stays on-topic.

## Rejected

Nothing in the report was wrong — all five reproduced. Two notes on scope:

* Defect 3 called the gate "near-redundant" and implied it could be deleted. I
  kept it, because it is the only thing in the pipeline that emits a per-file
  `::error file=` annotation pointing at the exact PNG, and it fires before
  `build` rather than after. What I removed is the *false* justification and the
  duplicated, weaker re-implementation of `missingShots`.
* Defect 5 only named `question-typed`, but fixing the typed string alone would
  have introduced a new continuity break (type X, next scene answers Y), so
  `ask-a-question` and `check-the-sources` are updated with it.

## Verification

Ran against a real capture, not a dry run:

* `ci-video capture` (video-kit 0.1.2, Playwright, static stage over `public/`)
  → **14 captured, 0 failed**, and **zero duplicate sha256 hashes** across the
  14 PNGs (was 1 duplicate pair before).
* `ci-video build` → both cuts, 55s.
* `ci-video check` → Layout 0 issues / Motion 0 errors, 0 warnings / Contrast
  10/10 WCAG AA / **both formats pass**.
* `storyboard.json` validates against the video-kit storyboard schema
  (unchanged between 0.1.1 and 0.1.2).
* Narration guard: **10 ok, 0 truncated, 0 missing**. Every narrated scene has an
  mp3 and every mp3 has a narrated scene — no audio was added or regenerated,
  because no narration text changed.
* `question-typed` re-captured in two separate runs produced identical hashes,
  so the new composer state is byte-stable.

No shot PNGs are committed (`video/assets/shots/` holds only `.gitkeep`).

**Not fixed here, and not fixable from a workflow file:** the capture stage
cannot yet run in CI — installing the video toolchain requires a registry
permission this repo does not have. `video.yml` already documents this and is
left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

