### PR TITLE
ci(video): install FFmpeg before the render step

### DIFF
--- a/.github/workflows/video.yml
+++ b/.github/workflows/video.yml
@@ -154,6 +154,21 @@ jobs:
         working-directory: video
         run: npm run build && npm run check
 
+      # The ubuntu-latest (24.04) runner image does NOT ship FFmpeg, and
+      # `npm run render` needs both binaries: ffmpeg to encode the MP4 and
+      # ffprobe to probe the media assets. Without this step the render aborts
+      # with "FFmpeg not found / FFprobe not found" and no MP4 is ever produced,
+      # even though every shot captured cleanly. Do not delete this as
+      # redundant — nothing else in this workflow installs it.
+      #
+      # Guarded by the same condition as Render below so a capture-only run
+      # (render=false) does not pay for the apt install.
+      - name: Install FFmpeg
+        if: ${{ github.event_name == 'schedule' || inputs.render }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
       - name: Render
         if: ${{ github.event_name == 'schedule' || inputs.render }}
         working-directory: video


### PR DESCRIPTION
## The bug

`.github/workflows/video.yml` runs `npm run render` in its **Render** step, which shells out to `ffmpeg` to encode the MP4 and `ffprobe` to probe the media assets. The `ubuntu-latest` (24.04) runner image does **not** ship FFmpeg, and nothing in the workflow installs it, so the render dies immediately:

```
✗  FFmpeg not found
   FFmpeg is required to encode video. The render cannot proceed without it.
✗  FFprobe not found
   FFprobe is required to probe media assets.
```

Net effect: capture works and every shot PNG lands, but no MP4 has ever been encoded — the `video/out/*.mp4` half of the upload artifact is always empty.

## The fix

Add an `Install FFmpeg` step immediately before **Render**:

```yaml
- name: Install FFmpeg
  if: ${{ github.event_name == 'schedule' || inputs.render }}
  run: |
    sudo apt-get update
    sudo apt-get install -y --no-install-recommends ffmpeg
```

It carries the **same `if:` guard the Render step already uses**, so a capture-only run (`render=false` via `workflow_dispatch`) does not pay for the apt install. The `ffmpeg` package provides `ffprobe` too, so one install covers both binaries.

A comment above the step records why it exists — the runner image lacks FFmpeg and the render needs both binaries — so it does not get deleted later as redundant.

## Verification

- YAML parses; the job now has 14 steps (was 13).
- Diff touches `.github/workflows/video.yml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)