### PR TITLE
chore(video): pin Playwright to 1.62.1 exactly

### DIFF
--- a/video/README.md
+++ b/video/README.md
@@ -107,3 +107,16 @@ screen the video covers, re-run the capture yourself and watch the result before
 
 See [CI-Engineering `projects/product-video-pipeline/`](https://github.com/companionintelligence/CI-Engineering/tree/main/projects/product-video-pipeline)
 for the full contract.
+
+## Why Playwright is pinned exactly
+
+`video/package.json` pins `playwright` to an exact version, not a range.
+
+Captures are byte-stable — that is what makes committing the shots worthwhile, because a UI change
+then lands as a reviewable image diff instead of noise. But that property only holds **within one
+Chromium build**. A `^1.58.0` range resolved to 1.62.1 on one machine and rewrote every committed
+shot in a repo by 0.07–0.47% of pixels: pure text antialiasing, no layout change, and completely
+indistinguishable from a real UI change in review.
+
+So the range is gone. Re-pin deliberately when you want the newer browser, and re-capture the whole
+shot set in the same commit.

--- a/video/package.json
+++ b/video/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "@companionintelligence/video-kit": "^0.1.0",
-    "playwright": "^1.58.0"
+    "playwright": "1.62.1"
   }
 }


### PR DESCRIPTION
`video/package.json` pinned `playwright` to `^1.58.0`. That range resolved to **1.62.1** on one machine and rewrote *every* committed shot in CI-Portal — 0.07–0.47% of pixels each, pure text antialiasing, no layout change, and indistinguishable from a real UI change in review.

Byte-stable capture is what makes committing the shots worth doing. It holds within one Chromium build and not across builds, so the range has to go.

Pinned to `1.62.1`: the build that produced the shots committed here. Anything else invalidates them.

No behaviour change until someone next runs `ci-video capture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)