### PR TITLE
fix(ui): repair the defects the store screenshots exposed

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -65,7 +65,29 @@
       .replace(/((?:<li>.*<\/li>\n?)+)/g, '<ul>$1</ul>')
       .replace(/\n\n+/g, '</p><p>')
       .replace(/\n/g, '<br>');
-    return '<p>' + html + '</p>';
+
+    html = '<p>' + html + '</p>';
+
+    // The `\n` → `<br>` pass above fires inside the <ul> it just built and
+    // right after its closing tag, so a three-bullet answer rendered as
+    // <ul><li>…</li><br><li>…</li>…</ul><br> — a stray break between every
+    // pair of bullets (invalid as a child of <ul>) plus one more under the
+    // list. The blocks also sit inside the wrapping <p>, which the parser
+    // force-closes, leaving an empty paragraph that keeps its bottom margin.
+    // Together those are the ragged gaps in the answer bubble.
+    return html
+      // stray breaks introduced around block boundaries
+      .replace(/<br>\s*(?=<\/?(?:ul|ol|li|h[2-4]|pre)\b)/g, '')
+      .replace(/(<\/(?:ul|ol|h[2-4]|pre)>)\s*<br>/g, '$1')
+      // lift blocks out of the paragraph instead of letting the parser do it
+      .replace(/(<(?:ul|ol|h[2-4]|pre)\b)/g, '</p>$1')
+      .replace(/(<\/(?:ul|ol|h[2-4]|pre)>)/g, '$1<p>')
+      .replace(/<p>\s*<\/p>/g, '');
+  }
+
+  function formatCount(n) {
+    const v = Number(n);
+    return Number.isFinite(v) ? v.toLocaleString('en-US') : '—';
   }
 
   function formatUptime(seconds) {
@@ -171,10 +193,13 @@
   function renderChips() {
     const wrap = $('chips');
     wrap.innerHTML = '';
-    SUGGESTED_PROMPTS.forEach((p) => {
+    SUGGESTED_PROMPTS.forEach((p, i) => {
       const b = document.createElement('button');
       b.type = 'button';
-      b.className = 'chip';
+      // At 360px every chip is its own row; six of them took two thirds of the
+      // viewport and pushed the welcome copy under the composer, cutting the
+      // last line in half. CSS drops the overflow below 620px.
+      b.className = 'chip' + (i >= 3 ? ' chip-extra' : '');
       b.textContent = p;
       b.addEventListener('click', () => {
         $('user-input').value = p;
@@ -186,10 +211,13 @@
 
   // ── Status & library ───────────────────────────────────────────────
 
-  function setPill(kind, text) {
+  // `detail` is the secondary half of the pill ("· 32 docs"). It is dropped
+  // below 620px, where the full string pushed "New chat" onto a second line.
+  function setPill(kind, text, detail) {
     const pill = $('status-pill');
     pill.className = 'status-pill ' + kind;
     pill.querySelector('.pill-text').textContent = text;
+    $('pill-detail').textContent = detail ? ' · ' + detail : '';
   }
 
   function setBanner(text) {
@@ -209,13 +237,20 @@
       const s = await res.json();
       state.statusFailures = 0;
 
-      $('st-engine').textContent = s.llm_loaded ? 'online' : 'degraded';
+      // "online"/"degraded" read as a contradiction next to the app's own
+      // "Runs 100% offline" footer. This field is really about whether the
+      // local weights are resident, so say that.
+      $('st-engine').textContent = s.llm_loaded ? 'model loaded' : 'no model';
       $('st-engine').className = s.llm_loaded ? 'ok' : 'err';
-      $('st-index').textContent = `${s.documents_indexed} chunks / ${s.files_processed} files`;
+      $('st-index').textContent =
+        `${formatCount(s.documents_indexed)} chunks · ${formatCount(s.files_processed)} files`;
       $('st-index').className = s.documents_indexed > 0 ? 'ok' : 'warn';
       $('st-model').textContent = s.llm_model || '—';
-      $('st-uptime').textContent = formatUptime(s.uptime_seconds || 0);
+      $('st-embed').textContent = s.embedding_model || '—';
       $('st-version').textContent = 'v' + (s.version || '?');
+      $('sidebar-footer').title = s.uptime_seconds
+        ? 'Server up ' + formatUptime(s.uptime_seconds)
+        : '';
 
       if (!s.llm_loaded) {
         setPill('err', 'LLM missing');
@@ -227,7 +262,7 @@
         setPill('warn', 'Index empty');
         setBanner('');
       } else {
-        setPill('ok', `Ready · ${s.files_processed} docs`);
+        setPill('ok', 'Ready', `${formatCount(s.files_processed)} docs`);
         setBanner('');
       }
 
@@ -386,8 +421,20 @@
 
   // ── Init ───────────────────────────────────────────────────────────
 
+  // The full placeholder is 38 characters and overflowed the narrow composer,
+  // so it read as "Ask an emergency or survival (" — a clipped string, not a
+  // prompt. CSS cannot swap placeholder text, so match the viewport here.
+  function syncPlaceholder() {
+    const narrow = window.matchMedia('(max-width: 620px)').matches;
+    $('user-input').placeholder = narrow
+      ? 'Ask a survival question…'
+      : 'Ask an emergency or survival question…';
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     initTheme();
+    syncPlaceholder();
+    window.matchMedia('(max-width: 620px)').addEventListener('change', syncPlaceholder);
     showWelcome();
     renderChips();
 

--- a/public/index.html
+++ b/public/index.html
@@ -32,9 +32,9 @@
         <h2 class="panel-title">System</h2>
         <dl class="status-grid" id="status-grid">
           <div><dt>Engine</dt><dd id="st-engine">—</dd></div>
-          <div><dt>Index</dt><dd id="st-index">—</dd></div>
           <div><dt>Model</dt><dd id="st-model">—</dd></div>
-          <div><dt>Uptime</dt><dd id="st-uptime">—</dd></div>
+          <div class="status-wide"><dt>Retrieval</dt><dd id="st-embed">—</dd></div>
+          <div class="status-wide"><dt>Index</dt><dd id="st-index">—</dd></div>
         </dl>
       </section>
 
@@ -47,7 +47,11 @@
         </div>
       </section>
 
-      <footer class="sidebar-footer">
+      <!-- Uptime is operational telemetry, not something a user reads: it was
+           the only volatile value on screen, so every product screenshot had
+           to mask it and shipped a blank tile where a stat should be. It is
+           still reported — as this footer's tooltip — just not rendered. -->
+      <footer class="sidebar-footer" id="sidebar-footer">
         <span class="offline-dot" aria-hidden="true"></span>
         <span>Runs 100% offline · <span id="st-version">v—</span></span>
       </footer>
@@ -61,14 +65,20 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
         </button>
         <div class="status-pill" id="status-pill" role="status">
-          <span class="pill-dot"></span><span class="pill-text">Connecting…</span>
+          <span class="pill-dot"></span><span class="pill-text">Connecting…</span><span
+            class="pill-detail" id="pill-detail"></span>
         </div>
         <div class="topbar-actions">
           <label class="toggle" title="Ground answers in the document library">
-            <input type="checkbox" id="context-toggle" checked>
-            <span>Use library</span>
+            <input type="checkbox" id="context-toggle" checked
+                   aria-label="Ground answers in the document library">
+            <span class="toggle-long">Use library</span>
+            <span class="toggle-short">Library</span>
           </label>
-          <button class="ghost-btn" id="new-chat-btn">New chat</button>
+          <button class="ghost-btn" id="new-chat-btn" aria-label="Start a new chat">
+            <svg class="ghost-btn-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></svg>
+            <span class="ghost-btn-label">New chat</span>
+          </button>
           <button class="icon-btn" id="theme-toggle" aria-label="Toggle light/dark theme">
             <svg class="icon-sun" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="4" fill="currentColor"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9l2.1 2.1M17 17l2.1 2.1M19.1 4.9L17 7M7 17l-2.1 2.1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
             <svg class="icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z" fill="currentColor"/></svg>
@@ -86,8 +96,8 @@
           <input type="text" id="user-input" class="composer-input" autocomplete="off"
                  placeholder="Ask an emergency or survival question…"
                  aria-label="Ask an emergency or survival question">
-          <button type="submit" class="send-btn" id="send-button">
-            <span>Send</span>
+          <button type="submit" class="send-btn" id="send-button" aria-label="Send question">
+            <span class="send-btn-label">Send</span>
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12l18-9-6 9 6 9-18-9z" fill="currentColor"/></svg>
           </button>
         </form>

--- a/public/style.css
+++ b/public/style.css
@@ -238,6 +238,11 @@ body {
 
 .status-grid div { min-width: 0; }
 
+/* "11,490 chunks · 32 files" never fit a half-width column and ellipsised to
+   "11490 chunks / 3…" — the app failing to show its own headline number.
+   The long stats get the full panel width. */
+.status-grid .status-wide { grid-column: 1 / -1; }
+
 .status-grid dt {
   font-family: var(--mono);
   font-size: 0.62rem;
@@ -360,6 +365,7 @@ body {
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-shrink: 0;
 }
 
 .icon-btn, .ghost-btn {
@@ -383,11 +389,20 @@ body {
 .icon-btn svg { width: 18px; height: 18px; }
 
 .ghost-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 6px 12px;
   font-size: 0.8rem;
   font-family: var(--mono);
   letter-spacing: 0.04em;
+  /* without this the button wrapped to two lines the moment the topbar ran
+     out of room, which is what "New / chat" was in the 360px shots */
+  white-space: nowrap;
+  flex-shrink: 0;
 }
+
+.ghost-btn-icon { display: none; width: 16px; height: 16px; }
 
 .icon-btn:hover, .ghost-btn:hover {
   background: var(--bg3);
@@ -439,6 +454,8 @@ body {
 }
 
 .toggle input { accent-color: var(--accent); cursor: pointer; }
+
+.toggle-short { display: none; }
 
 /* ── Banner (degraded mode) ─────────────────────────────────────── */
 
@@ -762,6 +779,43 @@ body {
   }
 
   #sidebar-toggle { display: inline-flex; }
+}
 
-  .toggle span { display: none; }
+/* ── Narrow phones (the 360px capture viewport) ─────────────────────
+   Everything below is one problem: the topbar and the composer were laid
+   out for a tablet and simply ran out of horizontal room at 360px, so
+   controls wrapped, labels vanished and both the hero copy and the input
+   text were sliced. Shed the optional words instead of the useful ones. */
+
+@media (max-width: 620px) {
+  .topbar { gap: 8px; padding: 10px 12px; }
+  .topbar-actions { gap: 8px; }
+
+  /* the doc count is already the FIELD LIBRARY badge in the drawer */
+  .pill-detail { display: none; }
+  .status-pill { padding: 5px 10px; }
+
+  /* "Use library" previously collapsed to a bare, unlabelled checkbox */
+  .toggle-long { display: none; }
+  .toggle-short { display: inline; }
+  .toggle { font-size: 0.68rem; gap: 5px; }
+
+  .ghost-btn { padding: 6px 9px; }
+  .ghost-btn-icon { display: block; }
+  .ghost-btn-label { display: none; }
+
+  .welcome { padding: 18px 0 4px; }
+  .welcome .brand-mark { width: 48px; height: 48px; }
+  .welcome h1 { font-size: 1.3rem; }
+  .welcome p { font-size: 0.94rem; }
+
+  /* six one-per-row chips left the hero no room and cut its last line */
+  .chip-extra { display: none; }
+
+  .composer { padding: 8px 12px 10px; }
+  .composer-input { font-size: 0.98rem; padding: 10px 12px; }
+  .send-btn { padding: 0 13px; }
+  .send-btn-label { display: none; }
+  .send-btn svg { width: 16px; height: 16px; }
+  .disclaimer { font-size: 0.64rem; }
 }

--- a/video/storyboard.json
+++ b/video/storyboard.json
@@ -58,9 +58,6 @@
               {
                 "waitFor": ".chips .chip"
               }
-            ],
-            "mask": [
-              "#st-uptime"
             ]
           }
         }
@@ -94,9 +91,6 @@
               {
                 "wait": 150
               }
-            ],
-            "mask": [
-              "#st-uptime"
             ]
           }
         }
@@ -136,9 +130,6 @@
               {
                 "wait": 150
               }
-            ],
-            "mask": [
-              "#st-uptime"
             ]
           }
         }
@@ -175,9 +166,6 @@
               {
                 "eval": "(() => { const i = document.getElementById('user-input'); i.setSelectionRange(0, 0); i.scrollLeft = 0; })()"
               }
-            ],
-            "mask": [
-              "#st-uptime"
             ]
           }
         }
@@ -220,9 +208,6 @@
               {
                 "waitFor": "details.sources > summary"
               }
-            ],
-            "mask": [
-              "#st-uptime"
             ]
           }
         }
@@ -274,9 +259,6 @@
               {
                 "wait": 150
               }
-            ],
-            "mask": [
-              "#st-uptime"
             ]
           }
         }
@@ -307,9 +289,6 @@
               {
                 "waitFor": ".lib-file"
               }
-            ],
-            "mask": [
-              "#st-uptime"
             ]
           }
         }


### PR DESCRIPTION
Found by opening all 14 committed product screenshots at full resolution
(`~/Movies/CI-Product-Videos/_assets/shots/just-in-case/`) and judging them as a
store listing. Everything here is fixed in `public/`; the only `video/` change is
deleting seven masks that no longer have anything to mask.

## Desktop

**The SYSTEM card ellipsised its own headline number** to `11490 chunks / 3…`.
`.status-grid dd` is `nowrap` + `ellipsis` inside a `1fr 1fr` grid, and that
string never fitted half a 240px panel. Index and Retrieval take the full panel
width now, and counts get thousands separators: **`11,490 chunks · 32 files`**.

**UPTIME rendered as an empty tile** in all seven desktop shots. It is the only
volatile value in the UI, so every shot masked it — *the mask was the blank box*.
Uptime is operator telemetry, not something a reader acts on, so it moves to the
sidebar footer's `title` and the seven now-pointless `"mask": ["#st-uptime"]`
entries come out of `storyboard.json`. The freed slot goes to `embedding_model`,
which `/status` has always returned and the UI has never shown — a genuinely
useful thing to see on a RAG appliance, and stable enough that it needs no mask.

**ENGINE read `online`** directly above the app's own `Runs 100% offline` footer.
Same field, honest wording: **`model loaded` / `no model`**.

**The answer bubble had ragged gaps between every bullet.** `renderMarkdown`'s
`\n` → `<br>` pass fires *inside* the `<ul>` it just built, so a three-bullet
answer came out as `<ul><li>…</li><br><li>…</li><br><li>…</li><br></ul><br>` —
a stray break between each pair, invalid as a child of `<ul>` — and the blocks
sat inside a `<p>` the parser force-closes, leaving an empty paragraph that keeps
its bottom margin. The bubble in `answer.png` is ~4× taller than its content
needs. Now:

```html
<p><strong>Boil, filter, or treat…</strong></p><ul><li>…</li><li>…</li><li>…</li></ul><p>Let cloudy water settle…</p>
```

## 360px

| Defect | Fix |
|---|---|
| `New chat` wrapped to two lines | doc count leaves the pill (the drawer badge already carries it); the button goes icon-only with an `aria-label` |
| `Use library` collapsed to a bare unlabelled checkbox — the old CSS was literally `.toggle span { display: none }` | keeps a visible `Library`, plus an `aria-label` on the input |
| Hero paragraph cut through the middle of a line of text | six one-per-row suggestion chips took two thirds of the viewport; three below 620px, and the hero fits |
| Placeholder read `Ask an emergency or survival (` | 38 characters in a field with room for ~28. Send goes icon-only and the placeholder shortens with the viewport (CSS can't swap placeholder text, so `matchMedia` does) |

The `answer.mobile` frame's first line was sliced mid-glyph by the sticky header
because the whole conversation no longer fits; with the bubble at its correct
height it now fits in one screen, question through composer.

## Fixtures

The `/query` answer in `video/fixtures/query.water.json` is synthetic — written
for the video, not sampled from the cited PDFs, because the real backend needs
2.3GB of GGUF weights and does not sample deterministically. The library listing
and status payloads are real, generated from `sources.yaml` and `src/config.h`.
Unchanged by this PR; restating it because these shots are going on a store page.

## Verification

- Ran the real app at 1280×720 and 360×640 against the video fixtures serving
  `/status`, `/api/library` and `/query`; checked welcome, typed, answer and
  degraded states at both.
- `node scripts/lint-canon.mjs .` — pass (all `--primary` are CI teal).
- The C++ unit tests under `tests/unit` do not cover `public/` and were not run;
  `tests/container` needs a built image.

## Re-capture

All 14 shots need re-shooting. One storyboard note for whoever does it:
`question-typed.mobile` will still show the *end* of the typed string, because
the caret sits at the end of a 47-character question in a ~30-character field.
That is correct input behaviour, not a defect — but if you want the head of the
sentence in frame, set `selectionStart = 0` before the shutter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)