### PR TITLE
fix(ui): give the field library real titles, and set the GGUF path as a path

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -103,6 +103,28 @@
     return (bytes / 1048576).toFixed(1) + ' MB';
   }
 
+  // The field library is an inventory of documents, so it should list titles.
+  // Printing the raw basename cost it two ways: ".pdf" repeated on 27 of 32
+  // rows carried no information and used the width that ran ten names into an
+  // ellipsis, and hyphen-joined words read as identifiers rather than as the
+  // books they are. The exact filename stays on the row's `title`, and every
+  // citation in an answer still prints the full path unchanged — this is the
+  // sidebar's label only.
+  //
+  // A hyphen only becomes a space where it is joining words: before an
+  // uppercase letter, or after a lowercase one. That leaves document numbers
+  // intact ("FM3-25-26-Map-Reading" → "FM3-25-26 Map Reading", not
+  // "FM3 25 26 Map Reading") and never touches CamelCase, so "OpenStax",
+  // "ThinkOS" and "Eloquent-JavaScript" survive.
+  function displayTitle(filename) {
+    const base = String(filename).split('/').pop();
+    return base
+      .replace(/\.(pdf|txt|md|epub|html?)$/i, '')
+      .replace(/[_-](?=[A-Z])/g, ' ')
+      .replace(/(?<=[a-z])[_-]/g, ' ')
+      .trim();
+  }
+
   // ── Chat rendering ─────────────────────────────────────────────────
 
   function addMessage(role, content, opts = {}) {
@@ -220,14 +242,31 @@
     $('pill-detail').textContent = detail ? ' · ' + detail : '';
   }
 
-  function setBanner(text) {
+  // `parts` are plain strings, except that a { path } object is rendered as a
+  // <code> span. The degraded-mode banner names the directory to drop the GGUF
+  // files into — the one actionable thing a self-hoster needs from it — and set
+  // in running prose an absolute container path reads as a leaked debug string.
+  // Marking it up as a path says "this is a literal to copy", which is what it
+  // is, without replacing the instruction with vaguer prose.
+  function setBanner(...parts) {
     const b = $('banner');
-    if (text) {
-      b.textContent = text;
-      b.hidden = false;
-    } else {
+    b.textContent = '';
+    const filled = parts.filter((p) => p && (typeof p !== 'string' || p.length));
+    if (!filled.length) {
       b.hidden = true;
+      return;
     }
+    for (const part of filled) {
+      if (typeof part === 'string') {
+        b.appendChild(document.createTextNode(part));
+      } else {
+        const code = document.createElement('code');
+        code.className = 'banner-path';
+        code.textContent = part.path;
+        b.appendChild(code);
+      }
+    }
+    b.hidden = false;
   }
 
   async function refreshStatus() {
@@ -245,7 +284,12 @@
       $('st-index').textContent =
         `${formatCount(s.documents_indexed)} chunks · ${formatCount(s.files_processed)} files`;
       $('st-index').className = s.documents_indexed > 0 ? 'ok' : 'warn';
+      // Same contradiction the Engine field had, one tile over: in degraded
+      // mode "no model" sat next to a confidently-lit "llama3.2:3b". The name
+      // is the configured model, so when it is not resident it is dimmed
+      // rather than presented as the running one.
       $('st-model').textContent = s.llm_model || '—';
+      $('st-model').className = s.llm_loaded ? '' : 'idle';
       $('st-embed').textContent = s.embedding_model || '—';
       $('st-version').textContent = 'v' + (s.version || '?');
       $('sidebar-footer').title = s.uptime_seconds
@@ -254,16 +298,18 @@
 
       if (!s.llm_loaded) {
         setPill('err', 'LLM missing');
-        const where = s.gguf_dir || 'gguf_models/';
-        setBanner('Language model not loaded — drop the GGUF files into ' + where +
-                  ' and they load automatically within ~30s (no restart needed). ' +
-                  'The library stays browsable; answers are unavailable.');
+        setBanner(
+          'Language model not loaded — drop the GGUF files into ',
+          { path: s.gguf_dir || 'gguf_models/' },
+          ' and they load automatically within ~30s (no restart needed). ' +
+          'The library stays browsable; answers are unavailable.'
+        );
       } else if (s.documents_indexed === 0) {
         setPill('warn', 'Index empty');
-        setBanner('');
+        setBanner();
       } else {
         setPill('ok', 'Ready', `${formatCount(s.files_processed)} docs`);
-        setBanner('');
+        setBanner();
       }
 
       if (s.files_processed !== state.lastFileCount) {
@@ -317,9 +363,8 @@
           a.target = '_blank';
           a.rel = 'noopener';
           a.title = f.filename + (f.size_bytes ? ` · ${formatSize(f.size_bytes)}` : '');
-          const base = f.filename.split('/').pop();
           a.innerHTML =
-            `<span class="lib-name">${escapeHtml(base)}</span>` +
+            `<span class="lib-name">${escapeHtml(displayTitle(f.filename))}</span>` +
             `<span class="lib-chunks">${f.status === 'skipped' ? 'skipped' : f.chunks}</span>`;
           list.appendChild(a);
         });

--- a/public/style.css
+++ b/public/style.css
@@ -259,6 +259,7 @@ body {
   text-overflow: ellipsis;
 }
 
+.status-grid dd.idle { color: var(--fg-dim); }
 .status-grid dd.ok   { color: var(--ok); }
 .status-grid dd.warn { color: var(--warn); }
 .status-grid dd.err  { color: var(--err); }
@@ -312,12 +313,20 @@ body {
 
 .lib-file:hover { background: var(--bg3); }
 
+/* Dropping the ".pdf" suffix (see displayTitle) took the clipped rows from ten
+   to three. Those three are genuinely long titles, so give them a second line
+   rather than an ellipsis: the clamp only expands the rows that need it, which
+   costs three lines across the whole 32-document library instead of the row
+   height every fixed two-line layout would spend. */
 .lib-file .lib-name {
   flex: 1;
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow-wrap: anywhere;
 }
 
 .lib-file .lib-chunks {
@@ -465,6 +474,17 @@ body {
   border-bottom: 1px solid var(--line);
   color: var(--warn);
   font-size: 0.82rem;
+}
+
+/* The GGUF directory is a literal the reader has to act on, not prose. Setting
+   it as a path stops it reading as a debug string leaking into the UI. */
+.banner-path {
+  font-family: var(--mono);
+  font-size: 0.95em;
+  padding: 1px 6px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--warn) 14%, transparent);
+  white-space: nowrap;
 }
 
 /* ── Chat ───────────────────────────────────────────────────────── */


### PR DESCRIPTION
Round two on the store screenshots. The first pass (#39) fixed 7 JustInCase defects and recorded 3 it left; these are those 3 — two fixed, one confirmed correct to leave, plus one adjacent contradiction found while measuring.

## 1. Sidebar filenames truncated — fixed

**Left because:** "the sidebar is a fixed 240px… fixing it properly means either a wider sidebar (which costs chat width) or two-line rows (which halves how many documents are visible). Both are worse trades than the current ellipsis."

Two of those premises turned out not to hold when measured.

- The sidebar is **304px**, not 240 (`public/style.css:153`), leaving 198px for a name.
- The choice was not two-way. `.pdf` is repeated on 27 of 32 rows, carries nothing a reader needs, and is using exactly the width that runs the names off the end.

`displayTitle()` drops the extension and turns *word-joining* hyphens into spaces, so the panel reads as the library it is — "Where There Is No Doctor", "Emergency War Surgery 5th Edition", "FEMA Emergency Checklist" — rather than as a directory listing. A hyphen only becomes a space before an uppercase letter or after a lowercase one, which keeps document numbers whole (`FM3-25-26`, `FM21-76`, `CISA NIFOG-2.02`) and never touches CamelCase, so OpenStax, ThinkOS and Eloquent JavaScript survive.

Measured at 1920×1080 against the committed fixtures:

| | clipped rows | library scroll height | rows visible without scrolling |
|---|---|---|---|
| before | **10 / 32** | 1288px | 17 |
| extension dropped | 3 / 32 | — | — |
| + `line-clamp: 2` | **0 / 32** | 1353px (+5%) | **17** |

The clamp only expands the three rows that need it, which is why the density cost is three lines across the whole library rather than the halving a fixed two-line row would have meant. The exact filename stays on each row's `title`, and answer citations still print the full path (`100_Survival/FM21-76-US-Army-Survival.pdf`) untouched — this is the sidebar's label only.

## 2. Degraded banner's `/app/gguf_models` — kept, but no longer looks like a debug leak

**Left because:** "it comes from the server's real `gguf_dir` config value and is the actionable instruction a self-hoster needs. Replacing it with prose would make the frame prettier and the app less useful."

Agreed on the substance — the path stays, same value from `/status`, same words around it. But the stated defect was that it *looks like* a debug string, and that is a presentation problem with a presentation fix: it is now marked up as a path (`<code class="banner-path">`) instead of sitting in running prose. Same information, reads as a literal to copy. Verified legible in both themes.

## 3. `answer.mobile` clipped mid-glyph — confirmed no longer reachable, still declining the general guard

**Left because:** "with the markdown fix the whole answer now fits in one 360×640 screen so it no longer happens, but I did not add scroll-padding to guard the general case."

Verified that claim rather than taking it: driven at 360×640 against the fixtures, the question, the full three-bullet answer and the SOURCES row all fit one screen with no scroll. And the premise for declining is right — `.chat` is a flex sibling below `.topbar`, not content under a sticky header, so there is nothing overlapping it to pad away. See "still not fixed" in the summary for what a real fix would be.

## Bonus, found while measuring

`MODEL: llama3.2:3b` sat lit next to `ENGINE: no model` on the degraded frame — the same contradiction #39 fixed one tile over. The configured name is now dimmed when the weights are not resident.

## Verification (real output)

| gate | result |
|---|---|
| `node --check public/app.js` | ✅ |
| `node scripts/lint-canon.mjs .` | ✅ canon OK (66 css/markup, 132 component files) |

The repo's other gates are C++ unit tests (`make -C tests/unit`) and a Docker smoke test that compiles llama.cpp and MuPDF — this PR touches only `public/app.js` and `public/style.css`, no C++ and no build inputs. Behaviour driven with Playwright against `python3 -m http.server --directory public` plus the committed `video/fixtures` stubs (the same stage `video/capture.config.mjs` uses), at 1920×1080 and 360×640, dark and light: 0 clipped library rows, no body or topbar overflow, banner path legible in both themes.

## Screenshots need re-shooting

The whole sidebar changes, so all 14 shots. `degraded.png` / `.mobile.png` additionally gain the path chip and the dimmed model. No storyboard edits needed — #39 already removed the seven `#st-uptime` masks and nothing here introduces a new volatile value.