### PR TITLE
docs(video): make.sh header says the shots are gitignored; they are committed

### DIFF
--- a/video/make.sh
+++ b/video/make.sh
@@ -7,9 +7,10 @@
 #   ./video/make.sh --only <id>     re-shoot a single shot by id
 #   ./video/make.sh --keep-up       leave the stage running when it finishes
 #
-# Output lands in video/out/ and video/assets/shots/, both gitignored: the video
-# and the screenshots are build artifacts, regenerated on demand rather than
-# stored.
+# The rendered cut lands in video/out/, which is gitignored — a video is a build
+# artifact, rendered on demand. The screenshots land in video/assets/shots/ and
+# ARE committed: without them a checkout cannot render at all. Re-capture and
+# commit them whenever you change a screen the video covers.
 #
 # THIS FILE IS GENERIC — it is the same in every product repo. Everything
 # repo-specific lives in video/stage.sh, which defines stage_up and stage_down.


### PR DESCRIPTION
## What

`video/make.sh` opens with:

> Output lands in `video/out/` and `video/assets/shots/`, **both gitignored**: the video and the screenshots are build artifacts, regenerated on demand rather than stored.

Only the first half is true here. This repo's `video/.gitignore` ignores `out/`, `build/`, `.auth/` and `node_modules/` — not `assets/shots/` — and:

```
$ git ls-files video/assets/shots/ | grep -c '\.png$'
14
```

## Why it was true, and stopped being

The claim was accurate when written. It stopped being accurate on 2026-08-05, when the fleet reversed the policy: capturing locally is only cheap if you can capture at all, and just five of the twelve products have a stage that comes up. A gitignored shot set therefore meant nobody but the stage's author could render the cut, and most products were rendering every screen beat as a branded "capture pending" slate. Screenshots are inputs now, versioned like inputs, and staleness is handled by re-capturing in the same change as the UI edit.

## Why it is worth a PR

This header is not only a comment — it is the `--help` text (`sed -n '2,15p' "${BASH_SOURCE[0]}"`), and it tells you the wrong thing about your own working tree. **Re-running capture edits tracked files.** Someone who has just been told the screenshots are build artifacts has no reason to run `git diff video/assets/shots/` afterwards, or to commit the result — which is precisely the workflow the committed-shots policy depends on.

## Wording

Taken verbatim from Local-Bench, which corrected its copy when the policy changed. This file declares itself `THIS FILE IS GENERIC — it is the same in every product repo`, so the four repos still carrying the old text should not each invent new prose. After this change JustInCase, Local-Bench and CI-Spellbook are byte-identical again; CI-WebXR-Time-Machine and CI-Outreach retain pre-existing, unrelated drift in the Playwright-install block, which I left alone.

## Scope

Comments only — no executable line is touched. Verified with `bash -n video/make.sh`.

Companion PRs: the same claim in CI-Spellbook, CI-WebXR-Time-Machine, CI-Outreach, and the source of it in CI-Engineering#98 (`tools/stages.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)