### PR TITLE
video: pilot the kit's `focus` grammar on two scenes

### DIFF
--- a/video/storyboard.json
+++ b/video/storyboard.json
@@ -184,6 +184,11 @@
           "url": "just-in-case.local",
           "alt": "The typed question — how long to boil creek water — asked and answered in the chat, with a collapsed sources accordion",
           "motion": "push-in",
+          "_focusNote": "The film's first punch-in, and it arrives late on purpose: four earlier scenes are this same app shell, so the wide read is long since established and this scene can spend its dwell on the conversation instead of re-introducing the furniture. It ends on the question, the answer and the collapsed SOURCES row — the narration, line for line.\n\nThe 16:9 window is always SQUARE in normalised image coordinates, because the capture and the canvas are both 16:9. So the only lever a landscape rectangle has is its longer side: scale = 1.263 / max(w, h), clamped to [1.263, 2.4]. max here is 0.65, giving 1.943x. An earlier attempt pointed at the answer bubble alone (0.51) was therefore pointless — it asks for 2.48x, clamps to 2.4, and the extra 0.14 of window it wins slices the question bubble instead.\n\nPortrait is a different instrument. The mobile capture is already legible at rest, and its window is square-ish too, so any tight crop slices full-width body copy — there is no honest close-up available. What IS available is the reframe coverScale gives for free: w 1.0 asks for nothing tighter than full-bleed, the phone frame drops away and the screen grows 39%. That is the portrait shot-size change; a portrait crop is not.",
+          "focus": {
+            "landscape": { "x": 0.3, "y": 0.091, "w": 0.65, "h": 0.4 },
+            "portrait": { "x": 0.0, "y": 0.06, "w": 1.0, "h": 0.86 }
+          },
           "capture": {
             "path": "/?stage=ready",
             "waitFor": ".chips .chip",
@@ -218,6 +223,8 @@
       "kind": "screen",
       "chapter": "ask",
       "seconds": 6.5,
+      "transition": "cut",
+      "_transitionNote": "Forced by the focus on the scene before it, and measured rather than assumed. Both scenes now end full-bleed on the same app screen at nearly the same scale, and the default half-second cross-dissolve between them renders as two full-frame copies of the answer text sliding through each other — a screenful of overlapping body copy that reads as a broken render, not a transition. At rest the same dissolve was harmless, because both plates were small cards on a lot of empty ground. AUTHORING.md predicts this ('a cross-dissolve between two shots of the SAME app screen reads as a double-exposure ghost'); punching in is what makes it unmissable. Cut instead — which is also the right edit, since this is the escalation from the answer to its receipts.",
       "caption": "Every answer opens onto the documents behind it.",
       "narration": "See exactly which documents the answer came from. Verify before you act.",
       "shots": [
@@ -226,6 +233,10 @@
           "url": "just-in-case.local",
           "alt": "The expanded sources accordion listing the three documents the answer was drawn from, each with the passage that matched",
           "motion": "drift-down",
+          "_focusNote": "The credibility beat, and the one frame in this film that is genuinely unreadable wide: the filenames the caption promises — 100_Survival/FM21-76-US-Army-Survival.pdf and the two engineering handbooks — are about 13px on a 1080-tall canvas at rest. At 1.974x they are 26px and the claim is verifiable rather than asserted.\n\ndrift-down rather than push-in, and it has room: headroomDown is 100px against a 107px request, so the shot travels 0.063 of the plate down through the three cards instead of stalling. That matters — a focus that lands hard against the coverage clamp leaves drift-down with nowhere to go and renders DEAD STILL while the storyboard claims it moves. Worth re-checking with the kit's own focusState after any change to this rectangle.\n\nLANDSCAPE ONLY, deliberately. On mobile the source list is full-bleed body copy that is already comfortable to read, so the only portrait framing available would crop the card text at the sides. A format left out keeps the legacy move, which is the right answer here: 'this screen does not need a camera on 9:16' should render as a plain shot, not a confidently wrong one.",
+          "focus": {
+            "landscape": { "x": 0.3, "y": 0.28, "w": 0.64, "h": 0.6 }
+          },
           "capture": {
             "path": "/?stage=ready",
             "waitFor": ".chips .chip",


### PR DESCRIPTION
Pilot of the video-kit `focus` grammar on this film. **Storyboard only — no screenshots were re-captured, and none needed to be.** `focus` is a render-time camera over the committed PNGs.

## Why

Every `screen` scene in this cut is a full-frame browser card at the same scale. A contact sheet of the landscape cut is seventeen tiles of one composition with different pixels on it — you cannot tell `field-library` from `library-shelf` at a glance, because they differ only inside a 22%-wide sidebar. The kit has `focus` for exactly this and, across the fleet, only CI-Spatial-Companion-WebXR uses it.

## What changed

| scene | shot | landscape | portrait |
|---|---|---|---|
| `ask-a-question` | `answer` | push-in → **1.943x** on the question, the answer and the SOURCES row | full-bleed reframe, **1.394x** |
| `check-the-sources` | `sources-open` | drift-down at **1.974x** through the three source cards | *(none — legacy move)* |

Plus `transition: "cut"` on `check-the-sources` (see below).

`check-the-sources` is the film's credibility beat and the one frame that is genuinely unreadable wide: the filenames the caption promises are about 13px on a 1080-tall canvas at rest, and 26px after the push. `ask-a-question` arrives after four scenes of the same app shell, so the wide read is long since established.

## The transition is not scope creep — the focus caused it

At rest, the default half-second cross-dissolve between these two scenes was harmless: two small cards on a lot of empty ground. Once both end full-bleed on the same screen at nearly the same scale, the same dissolve renders as two full-frame copies of the answer text sliding through each other. It looks like a broken render. `AUTHORING.md` predicts it ("a cross-dissolve between two shots of the SAME app screen reads as a double-exposure ghost"); punching in is what makes it unmissable. `cut` also happens to be the right edit — this is the escalation from the answer to its receipts.

## Rectangles rejected after looking at rendered frames

Recorded in `_focusNote` so the next author does not re-derive them:

- **The field library rail.** 0.225 of the plate wide against a 0.526 minimum window, so any crop leaves 57% of the frame dead and slices the suggestion chips and the hero paragraph. There is no honest close-up of a narrow left rail in 16:9.
- **The typed-question composer.** A thin band at the bottom of an otherwise empty screen; the crop is mostly void and the typed text lands behind the caption.
- **The no-model banner.** The narration names the banner *and* the library staying browsable — opposite ends of the screen. Any window tight enough to read the banner drops the library, so the picture would contradict half the line. Left wide.

## Measured

Rendered locally on **video-kit 0.8.0** (CI-Common `origin/main` @ `988fc5a`), before and after, same machine and same kit.

| | dur | LUFS | dBTP | silent | frozen | slates |
|---|---|---|---|---|---|---|
| before, landscape | 51s | −14 | −2.7 | 0% | 0% | 0 |
| after, landscape | 51s | −14 | −2.7 | 0% | 0% | 0 |
| before, portrait | 51s | −14 | −2.7 | 0% | 0% | 0 |
| after, portrait | 51s | −14 | −2.7 | 0% | 0% | 0 |

Identical on every axis the bar measures — including frozen picture, which a focus push should never worsen. `ci-video check` passes both formats and the build emits no `capped` or `degraded` focus warnings, so every rectangle is honoured as written rather than silently clamped.

## Verified by looking

- Contact sheets of both formats, before and after. Row 3 of the landscape sheet now escalates — wide, mid-push, full-bleed answer, then the source cards — where before it was six identical tiles.
- Last frame of both focused scenes pulled and read: neither ends on empty canvas, and the drift-down ends with the top edge on a clean line break rather than through a row of type.
- The old dissolve point re-sampled after adding `cut`: the ghost is gone.

## Honest limits

- Two scenes out of seven changed. Rows 1, 2 and 4 of the contact sheet are unchanged, so the film still opens on ten near-identical tiles. The improvement is real and local, not transformative.
- The 9:16 cut gains one reframe, not a punch-in. A portrait window is square-ish and mobile layouts are full-width, so a tight crop would slice body copy; the only honest portrait move is dropping the phone frame and going full-bleed at 1.394x.
