### PR TITLE
fix(video): install Chromium through the Playwright that captures

### DIFF
--- a/video/make.sh
+++ b/video/make.sh
@@ -322,16 +322,26 @@ if [ -z "$PW_PIN" ]; then
 fi
 
 say "installing Chromium for Playwright"
-# Idempotent and cached under ~/Library/Caches/ms-playwright, so a no-op after
-# the first run. No --with-deps: that is an apt path and does nothing on macOS.
+# Through the kit, which resolves Playwright the way capture does. NOT
+# `npx --yes playwright install chromium`, which this file used to run.
 #
-# npx, not a hardcoded path: it walks up the same way node does, so it works
-# whether playwright came from video/node_modules (the block above installed it)
-# or from the repo root (the root already had the pinned version, so nothing was
-# installed here). Either way the guard above has already established that the
-# resolved version IS the pin, so the browser this downloads matches the
-# playwright that will drive it. It is a public package, so no auth is needed.
-npx --yes playwright install chromium
+# The old line was defended here on the grounds that npx "walks up the same way
+# node does". It does not. npx resolves a BINARY: it looks for a command called
+# `playwright` in node_modules/.bin, walking up — and @playwright/test provides
+# that command too, at whatever version the repo root pins for its e2e suite. If
+# it finds none it downloads the LATEST Playwright from the registry and runs
+# that. The version guard above proves which MODULE resolves; it says nothing
+# about which binary answers, so it could not have covered the difference.
+#
+# Any of those three installs a browser revision belonging to a Playwright that
+# is not the one about to shoot, and capture is byte-stable only within one
+# build: the wrong one rewrites every committed shot with different text
+# antialiasing, which reads in review as a real UI change. `ci-video
+# install-browser` derives the CLI from `require.resolve('playwright')` out of
+# video/ — the same lookup capture.mjs performs — so the browser and the driver
+# are the same installation by construction. It prints both, and says so when a
+# differing binary is on the path.
+kit install-browser
 
 say "capturing the UI"
 # Some repos cannot capture in one pass — a shot may need a different identity,


### PR DESCRIPTION
## What

`cp <CI-Common>/packages/video-kit/template/make.sh video/make.sh`. Nothing else. sha1 `bdb6d32d` → `93b5cf14`; `diff video/make.sh …/template/make.sh` now prints nothing.

`video/make.sh` is a byte-identical copy of the kit's template and carries **no per-repo configuration** — everything repo-specific lives in `video/stage.sh`. Seven repos ship the same copy, and all seven went stale against a correctness fix the kit landed in CI-Common #68.

## Why it matters

```diff
-npx --yes playwright install chromium
+kit install-browser
```

The old line came with a comment defending it: npx "walks up the same way node does". **It does not.** `npx` resolves a **binary** — a `playwright` command in `node_modules/.bin`, walking up — and `@playwright/test` provides that command too, at whatever version the repo root pins for its e2e suite. Finding none, it downloads the **latest** Playwright from the registry and runs that. Capture resolves a **module** from `video/`. Two different lookups over the same tree.

The Playwright version guard directly above that line proves which *module* resolves. It says nothing about which *binary* answers, so it never covered this.

`ci-video install-browser` derives the CLI from `require.resolve('playwright')` out of `video/` — the same lookup `capture.mjs` performs — so the browser and the driver are the same installation by construction. It prints both, and says so when a differing binary is on the PATH.

Captures are byte-stable only within one Playwright build. The wrong one rewrites every committed shot with text-antialiasing noise that arrives in review looking like a real UI change.

## The gate

Captured **before and after** the change, in a clean worktree at `origin/main`, against the same pinned kit (video-kit **0.13.0**, CI-Common `origin/main` `cff9d68`, template `93b5cf14`):

| | |
|---|---|
| committed → run with old `make.sh` | **14/14 PNGs identical** |
| run with old `make.sh` → run with new `make.sh` | **14/14 PNGs identical** |

The first row matters as much as the second: it establishes that the committed bytes reproduce at all, so the second row is a real comparison rather than two runs of the same broken code agreeing with each other.

Playwright resolved as pinned — `1.62.1`, from `video/node_modules`, installed by `make.sh` itself (this repo has no root `package.json`, so it is the cheapest of the seven to verify and was done first deliberately).

`git status` after both runs: `video/make.sh` only.

## Not merging yet

Draft. Stage 1 of the `make.sh` consolidation; the `doctor` check that makes this drift mechanical is CI-Common #72 and is also still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
