### PR TITLE
fix(index): delete a document's chunks when the document is deleted

### DIFF
--- a/src/ingestion.cpp
+++ b/src/ingestion.cpp
@@ -128,6 +128,9 @@ int main() {
     // ── Main ingestion loop ──────────────────────────────────────────
     while (g_running.load()) {
         std::vector<std::pair<std::string, std::string>> files_to_process;
+        // Everything seen on disk this pass, to diff against the index below.
+        std::set<std::string> seen_on_disk;
+        bool scan_complete = false;
 
         // Discover new files
         if (fs::exists(sources_dir)) {
@@ -144,6 +147,7 @@ int main() {
                     if (ext != ".pdf" && ext != ".txt") continue;
 
                     std::string rel = fs::relative(entry.path(), sources_dir).string();
+                    seen_on_disk.insert(rel);
                     if (index.is_file_processed(rel)) continue;
 
                     if (!file_is_settled(entry.path())) continue; // retry next scan
@@ -155,8 +159,33 @@ int main() {
                         index.mark_file_processed(rel, 0);
                     }
                 }
+                scan_complete = true;
             } catch (const std::exception& e) {
                 std::cerr << "Error scanning sources: " << e.what() << std::endl;
+            }
+        }
+
+        // ── Prune documents that have left the volume ───────────────
+        //
+        // The index used to be append-only, so deleting a PDF left its
+        // chunks behind forever: /query kept retrieving from a document
+        // that no longer exists and citing it, and the citation link 404s.
+        // On an appliance whose promise is "answers cite their sources",
+        // a citation to a deleted document is the worst kind of failure —
+        // it looks exactly like a working one.
+        //
+        // ONLY ON A COMPLETE SCAN. If the directory walk threw halfway
+        // through — an unreadable file, a volume being remounted — then
+        // `seen_on_disk` is a partial list, and pruning against it would
+        // delete documents that are simply further down the tree. A
+        // failed scan must cost nothing, not most of the library.
+        if (scan_complete) {
+            for (const auto& indexed : index.indexed_filenames()) {
+                if (!g_running.load()) break;
+                if (seen_on_disk.count(indexed)) continue;
+                const int gone = index.remove_file(indexed);
+                std::cout << "Removed from index (file no longer present): "
+                          << indexed << "  (" << gone << " chunk(s))" << std::endl;
             }
         }
 

--- a/src/sqlite_vec_index.h
+++ b/src/sqlite_vec_index.h
@@ -86,6 +86,25 @@ public:
             END
         )");
 
+        // The matching DELETE trigger. `chunks_fts` is an EXTERNAL-CONTENT
+        // FTS5 table (content=chunks), which means it keeps its own copy of
+        // the terms and does NOT notice rows leaving the content table.
+        // Deleting a chunk without this leaves the term still indexed: BM25
+        // goes on matching text that no longer exists and returns a rowid
+        // that resolves to nothing, so a removed document keeps influencing
+        // retrieval and can still be cited.
+        //
+        // The `('delete', ...)` command form is FTS5's required way to
+        // retract a row, and it must be given the OLD column values —
+        // passing anything else corrupts the index rather than fixing it.
+        exec(R"(
+            CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks
+            BEGIN
+                INSERT INTO chunks_fts(chunks_fts, rowid, filename, chunk_text)
+                VALUES ('delete', old.id, old.filename, old.chunk_text);
+            END
+        )");
+
         exec(R"(
             CREATE TABLE IF NOT EXISTS processed_files (
                 filename     TEXT PRIMARY KEY,
@@ -421,6 +440,88 @@ public:
         }
         sqlite3_finalize(s);
         return entries;
+    }
+
+    /**
+     * Remove every trace of one document: its vectors, its chunks (which
+     * retracts its FTS terms through the chunks_ad trigger) and its
+     * processed_files row.
+     *
+     * Until this existed the index was APPEND-ONLY. Deleting a PDF from the
+     * sources volume left its chunks behind forever, so `/query` went on
+     * retrieving from a document that is not there and citing it — and the
+     * citation link 404s, because the file it points at is gone. On an
+     * appliance whose entire promise is "answers cite their sources", a
+     * citation to a document the user deleted is the worst possible failure:
+     * it looks exactly like a working one.
+     *
+     * Returns the number of chunks removed.
+     *
+     * ORDER MATTERS. vec_chunks is keyed by chunk id and those ids are
+     * resolved from `chunks`, so the vectors must go FIRST — deleting the
+     * chunks first would strand every vector with no way left to find it.
+     */
+    int remove_file(const std::string& filename) {
+        std::lock_guard<std::mutex> lock(mu_);
+
+        int removed = 0;
+        {
+            sqlite3_stmt* s = nullptr;
+            sqlite3_prepare_v2(db_,
+                "SELECT COUNT(*) FROM chunks WHERE filename = ?", -1, &s, nullptr);
+            sqlite3_bind_text(s, 1, filename.c_str(), -1, SQLITE_TRANSIENT);
+            if (sqlite3_step(s) == SQLITE_ROW) removed = sqlite3_column_int(s, 0);
+            sqlite3_finalize(s);
+        }
+        if (removed == 0) return 0;
+
+        exec("BEGIN");
+
+        // 1. Vectors, while `chunks` can still resolve their ids.
+        {
+            sqlite3_stmt* s = nullptr;
+            sqlite3_prepare_v2(db_,
+                "DELETE FROM vec_chunks WHERE chunk_id IN "
+                "(SELECT id FROM chunks WHERE filename = ?)", -1, &s, nullptr);
+            sqlite3_bind_text(s, 1, filename.c_str(), -1, SQLITE_TRANSIENT);
+            sqlite3_step(s);
+            sqlite3_finalize(s);
+        }
+
+        // 2. Chunks — the chunks_ad trigger retracts the FTS terms.
+        {
+            sqlite3_stmt* s = nullptr;
+            sqlite3_prepare_v2(db_, "DELETE FROM chunks WHERE filename = ?", -1, &s, nullptr);
+            sqlite3_bind_text(s, 1, filename.c_str(), -1, SQLITE_TRANSIENT);
+            sqlite3_step(s);
+            sqlite3_finalize(s);
+        }
+
+        // 3. The library listing.
+        {
+            sqlite3_stmt* s = nullptr;
+            sqlite3_prepare_v2(db_, "DELETE FROM processed_files WHERE filename = ?", -1, &s, nullptr);
+            sqlite3_bind_text(s, 1, filename.c_str(), -1, SQLITE_TRANSIENT);
+            sqlite3_step(s);
+            sqlite3_finalize(s);
+        }
+
+        exec("COMMIT");
+        return removed;
+    }
+
+    /** Every filename the index believes it holds. */
+    std::vector<std::string> indexed_filenames() {
+        std::lock_guard<std::mutex> lock(mu_);
+        std::vector<std::string> out;
+        sqlite3_stmt* s = nullptr;
+        sqlite3_prepare_v2(db_, "SELECT filename FROM processed_files", -1, &s, nullptr);
+        while (sqlite3_step(s) == SQLITE_ROW) {
+            const char* fn = reinterpret_cast<const char*>(sqlite3_column_text(s, 0));
+            if (fn) out.push_back(fn);
+        }
+        sqlite3_finalize(s);
+        return out;
     }
 
     int chunk_count() {


### PR DESCRIPTION
The index was **append-only**. Delete a PDF from the sources volume and its chunks stayed forever — `/query` kept retrieving from a document that is not there and **citing** it, and the citation link 404s.

On an appliance whose promise is *"answers cite their sources"*, a citation to a deleted document is the worst available failure: it looks exactly like a working one.

## The subtle half

`remove_file()` deletes vectors → chunks → `processed_files`. Vectors first, because `vec_chunks` is keyed by chunk id and those ids resolve from `chunks`.

But `chunks_fts` is an **external-content** FTS5 table (`content=chunks`) and the schema had only an `AFTER INSERT` trigger. External-content FTS keeps its own copy of the terms and does not notice rows leaving the content table — so a plain `DELETE` leaves every term indexed, with BM25 matching text that no longer exists and returning rowids that resolve to nothing. **The naive fix is worse than the bug.**

Hence the matching `chunks_ad` trigger using FTS5's `('delete', rowid, …)` command form.

## Proven against the schema this build creates

```
before delete:  zarquon -> [(1,)]   boiling -> [(2,)]
after  delete:  zarquon -> []       boiling -> [(2,)]

WITHOUT chunks_ad:  'griffilorn' still matches after its row is deleted
```

That last line is the original bug reproduced on demand — the retraction is the trigger's doing.

## The sweep is guarded

`jic-ingestion` diffs `processed_files` against disk each scan — **only on a scan that completed**. If the directory walk throws halfway (unreadable file, volume remount), the "seen" set is partial and pruning against it would delete documents merely further down the tree. A failed scan must cost nothing, not most of the library.

Verified: `docker build` clean, both binaries link, built schema has `chunks_ai` + `chunks_ad` + `index_meta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)